### PR TITLE
XBus initialization

### DIFF
--- a/src/include/cpu/power/istep_8.h
+++ b/src/include/cpu/power/istep_8.h
@@ -9,5 +9,11 @@ void istep_8_1(uint8_t chips);
 void istep_8_2(uint8_t chips);
 void istep_8_3(uint8_t chips);
 void istep_8_4(uint8_t chips);
+void istep_8_9(uint8_t chips);
+
+/* These functions access SCOM of the second CPU using SBE IO, thus they can be
+ * used only in isteps that come after 8.4 */
+void put_scom(uint8_t chip, uint64_t addr, uint64_t data);
+uint64_t get_scom(uint8_t chip, uint64_t addr);
 
 #endif /* CPU_PPC64_ISTEP8_H */

--- a/src/include/cpu/power/istep_8.h
+++ b/src/include/cpu/power/istep_8.h
@@ -10,6 +10,7 @@ void istep_8_2(uint8_t chips);
 void istep_8_3(uint8_t chips);
 void istep_8_4(uint8_t chips);
 void istep_8_9(uint8_t chips);
+void istep_8_10(uint8_t chips);
 
 /* These functions access SCOM of the second CPU using SBE IO, thus they can be
  * used only in isteps that come after 8.4 */

--- a/src/include/cpu/power/istep_8.h
+++ b/src/include/cpu/power/istep_8.h
@@ -11,6 +11,7 @@ void istep_8_3(uint8_t chips);
 void istep_8_4(uint8_t chips);
 void istep_8_9(uint8_t chips);
 void istep_8_10(uint8_t chips);
+void istep_8_11(uint8_t chips);
 
 /* These functions access SCOM of the second CPU using SBE IO, thus they can be
  * used only in isteps that come after 8.4 */

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -15,6 +15,7 @@ romstage-y += istep_8_3.c
 romstage-y += istep_8_4.c
 romstage-y += istep_8_9.c
 romstage-y += istep_8_10.c
+romstage-y += istep_8_11.c
 romstage-y += istep_10_10.c
 romstage-y += istep_10_12.c
 romstage-y += istep_10_13.c

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -34,6 +34,7 @@ romstage-y += ccs.c
 romstage-y += mcbist.c
 romstage-y += timer.c
 romstage-y += fsi.c
+romstage-y += sbeio.c
 ramstage-y += chip.c
 ramstage-y += homer.c
 ramstage-y += rom_media.c

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -13,6 +13,7 @@ romstage-y += istep_8_1.c
 romstage-y += istep_8_2.c
 romstage-y += istep_8_3.c
 romstage-y += istep_8_4.c
+romstage-y += istep_8_9.c
 romstage-y += istep_10_10.c
 romstage-y += istep_10_12.c
 romstage-y += istep_10_13.c

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -14,6 +14,7 @@ romstage-y += istep_8_2.c
 romstage-y += istep_8_3.c
 romstage-y += istep_8_4.c
 romstage-y += istep_8_9.c
+romstage-y += istep_8_10.c
 romstage-y += istep_10_10.c
 romstage-y += istep_10_12.c
 romstage-y += istep_10_13.c

--- a/src/soc/ibm/power9/istep_8_10.c
+++ b/src/soc/ibm/power9/istep_8_10.c
@@ -1,0 +1,395 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/power/istep_8.h>
+
+#include <console/console.h>
+#include <cpu/power/scom.h>
+#include <delay.h>
+
+static inline void and_scom(uint8_t chip, uint64_t addr, uint64_t mask)
+{
+	put_scom(chip, addr, get_scom(chip, addr) & mask);
+}
+
+static inline void or_scom(uint8_t chip, uint64_t addr, uint64_t mask)
+{
+	put_scom(chip, addr, get_scom(chip, addr) | mask);
+}
+
+static inline void and_or_scom(uint8_t chip, uint64_t addr, uint64_t and, uint64_t or)
+{
+	uint64_t data = get_scom(chip, addr);
+	data &= and;
+	data |= or;
+	put_scom(chip, addr, data);
+}
+
+static void xbus_scom(uint8_t chip, uint8_t group)
+{
+	/* ATTR_IO_XBUS_CHAN_EQ is 0 by default and Hostboot logs seem to confirm this*/
+
+	/* ATTR_IO_XBUS_MASTER_MODE */
+	const bool xbus_master_mode = (chip == 0);
+	/*
+	 * Offset for group.
+	 *
+	 * Note that several registers are initialized for both groups and don't
+	 * use the offset.  Some other writes are group-specific and don't need
+	 * it either.
+	 */
+	const uint64_t offset = group * 0x2000000000;
+
+	int i;
+
+	/* *_RX_DATA_DAC_SPARE_MODE_PL */
+	for (i = 0; i < 18; i++) {
+		uint64_t addr = 0x8000000006010C3F + offset + 0x100000000 * i;
+		// 53 - *_RX_DAC_REGS_RX_DAC_REGS_RX_PL_DATA_DAC_SPARE_MODE_5_OFF
+		// 54 - *_RX_DAC_REGS_RX_DAC_REGS_RX_PL_DATA_DAC_SPARE_MODE_6_OFF
+		// 55 - *_RX_DAC_REGS_RX_DAC_REGS_RX_PL_DATA_DAC_SPARE_MODE_7_OFF
+		and_scom(chip, addr, ~PPC_BITMASK(53, 55));
+	}
+
+	/* *_RX_DAC_CNTL1_EO_PL */
+	for (i = 0; i < 18; i++) {
+		uint64_t addr = 0x8000080006010C3F + offset + 0x100000000 * i;
+		// 54 - *_RX_DAC_REGS_RX_DAC_REGS_RX_LANE_ANA_PDWN_{OFF,ON}
+		if (i < 17)
+			and_scom(chip, addr, ~PPC_BIT(54));
+		else
+			or_scom(chip, addr, PPC_BIT(54));
+	}
+
+	/* *_RX_DAC_CNTL5_EO_PL */
+	for (i = 0; i < 18; i++) {
+		uint64_t addr = 0x8000280006010C3F + offset + 0x100000000 * i;
+		and_scom(chip, addr,
+			 ~(PPC_BITMASK(48, 51) | PPC_BITMASK(52, 56) | PPC_BITMASK(57, 61)));
+	}
+
+	/* *_RX_DAC_CNTL6_EO_PL */
+	for (i = 0; i < 18; i++) {
+		uint64_t addr = 0x8000300006010C3F + offset + 0x100000000 * i;
+		and_or_scom(chip, addr,
+			    ~(PPC_BITMASK(53, 56) | PPC_BITMASK(48, 52)),
+			    PPC_PLACE(0x7, 53, 4) | PPC_PLACE(0x0C, 48, 5));
+	}
+
+	/* *_RX_DAC_CNTL9_E_PL */
+	for (i = 0; i < 18; i++) {
+		uint64_t addr = 0x8000C00006010C3F + offset + 0x100000000 * i;
+		and_scom(chip, addr, ~(PPC_BITMASK(48, 54) | PPC_BITMASK(55, 60)));
+	}
+
+	/* *_RX_BIT_MODE1_EO_PL */
+	for (i = 0; i < 18; i++) {
+		uint64_t addr = 0x8002200006010C3F + offset + 0x100000000 * i;
+		// 48 - *_RX_BIT_REGS_RX_LANE_DIG_PDWN_{OFF,ON}
+		if (i < 17)
+			and_scom(chip, addr, ~PPC_BIT(48));
+		else
+			or_scom(chip, addr, PPC_BIT(48));
+	}
+
+	/* *_RX_BIT_MODE1_E_PL */
+	for (i = 0; i < 17; i++) {
+		uint64_t addr = 0x8002C00006010C3F + offset + 0x100000000 * i;
+		const uint16_t data[17] = {
+			0x1000, 0xF03E, 0x07BC, 0x07C7, 0x03EF, 0x1F0F, 0x1800, 0x9C00,
+			0x1000, 0x9C00, 0x1800, 0x1F0F, 0x03EF, 0x07C7, 0x07BC, 0xF03E,
+			0x1000
+		};
+		and_or_scom(chip, addr, ~PPC_BITMASK(48, 63), PPC_PLACE(data[i], 48, 16));
+	}
+
+	/* *_RX_BIT_MODE2_E_PL */
+	for (i = 0; i < 17; i++) {
+		uint64_t addr = 0x8002C80006010C3F + offset + 0x100000000 * i;
+		const uint8_t data[17] = {
+			0x42, 0x3E, 0x00, 0x60, 0x40, 0x40, 0x03, 0x03,
+			0x42, 0x03, 0x03, 0x40, 0x40, 0x60, 0x00, 0x3E,
+			0x42
+		};
+		and_or_scom(chip, addr, ~PPC_BITMASK(48, 54), PPC_PLACE(data[i], 48, 7));
+	}
+
+	/* *_TX_MODE1_PL */
+	for (i = 0; i < 17; i++) {
+		uint64_t addr = 0x8004040006010C3F + offset + 0x100000000 * i;
+		and_scom(chip, addr, ~PPC_BIT(48));
+	}
+
+	/* *_TX_MODE2_PL */
+	for (i = 0; i < 17; i++) {
+		uint64_t addr = 0x80040C0006010C3F + offset + 0x100000000 * i;
+		or_scom(chip, addr, PPC_BIT(62));
+	}
+
+	/* *_TX_BIT_MODE1_E_PL */
+	for (i = 0; i < 17; i++) {
+		uint64_t addr = 0x80043C0006010C3F + offset + 0x100000000 * i;
+		const uint16_t data[17] = {
+			0x000, 0x000, 0x01E, 0x01F, 0x00F, 0x07C, 0xC63, 0xE73,
+			0x000, 0xE73, 0xC63, 0x07C, 0x00F, 0x01F, 0x01E, 0x000,
+			0x000,
+		};
+		and_or_scom(chip, addr, ~PPC_BITMASK(48, 63), PPC_PLACE(data[i], 48, 16));
+	}
+
+	/* *_TX_BIT_MODE2_E_PL */
+	for (i = 0; i < 17; i++) {
+		uint64_t addr = 0x8004440006010C3F + offset + 0x100000000 * i;
+		const uint8_t data[17] = {
+			0x01, 0x7C, 0x7B, 0x0C, 0x5E, 0x10, 0x0C, 0x4E,
+			0x01, 0x4E, 0x0C, 0x10, 0x5E, 0x0C, 0x7B, 0x7C,
+			0x01,
+		};
+		and_or_scom(chip, addr, ~PPC_BITMASK(48, 54), PPC_PLACE(data[i], 48, 7));
+	}
+
+	// P9A_XBUS_0_RX[01]_RX_SPARE_MODE_PG
+	// 49 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_PG_SPARE_MODE_1_ON
+	or_scom(chip, 0x8008000006010C3F + offset, PPC_BIT(49));
+
+	// P9A_XBUS_0_RX[01]_RX_ID1_PG
+	and_or_scom(chip, 0x8008080006010C3F + offset,
+		    ~PPC_BITMASK(48, 53),
+		    PPC_PLACE((group == 0 ? 0x00 : 0x01), 48, 6));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE1_EO_PG
+	// 48 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_CLKDIST_PDWN_OFF
+	and_scom(chip, 0x8008100006010C3F + offset, ~PPC_BIT(48));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE5_EO_PG
+	// 51-53 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DYN_RECAL_INTERVAL_TIMEOUT_SEL_TAP5
+	// 54-55 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DYN_RECAL_STATUS_RPT_TIMEOUT_SEL_TAP1
+	and_or_scom(chip, 0x8008300006010C3F + offset,
+		    ~(PPC_BITMASK(51, 53) | PPC_BITMASK(54, 55)),
+		    PPC_PLACE(0x5, 51, 3) | PPC_PLACE(0x1, 54, 2));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE7_EO_PG
+	and_or_scom(chip, 0x8008400006010C3F + offset,
+		    ~PPC_BITMASK(60, 63),
+		    PPC_PLACE(0xA, 60, 4));
+
+	// P9A_XBUS_0_RX0_RX_CTL_MODE23_EO_PG (same address for both groups)
+	// 55 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_PEAK_TUNE_OFF
+	// 56 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_LTE_EN_ON
+	// 59 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DFEHISPD_EN_ON
+	// 60 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DFE12_EN_ON
+	if (group == 0) {
+		and_or_scom(chip, 0x8008C00006010C3F,
+			~(PPC_BITMASK(48, 49) | PPC_BITMASK(55, 60)),
+			PPC_PLACE(0x1, 48, 2) | PPC_BIT(56) | PPC_PLACE(0x3, 57, 2) |
+			PPC_BIT(59) | PPC_BIT(60));
+	} else {
+		and_or_scom(chip, 0x8008C00006010C3F,
+			    ~PPC_BITMASK(48, 49), PPC_PLACE(0x1, 48, 2));
+	}
+
+	// P9A_XBUS_0_RX0_RX_CTL_MODE23_EO_PG
+	// 55 - IOF1_RX_RX1_RXCTL_CTL_REGS_RX_CTL_REGS_RX_PEAK_TUNE_OFF
+	// 56 - IOF1_RX_RX1_RXCTL_CTL_REGS_RX_CTL_REGS_RX_LTE_EN_ON
+	// 57 - 0b11
+	// 59 - IOF1_RX_RX1_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DFEHISPD_EN_ON
+	// 60 - IOF1_RX_RX1_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DFE12_EN_ON
+	if (group == 1) {
+		and_or_scom(chip, 0x8008C02006010C3F,
+			    ~PPC_BITMASK(55, 60),
+			    PPC_BIT(56) | PPC_PLACE(0x3, 57, 2) | PPC_BIT(59) | PPC_BIT(60));
+	}
+
+	// P9A_XBUS_0_RX0_RX_CTL_MODE29_EO_PG (identical for both groups)
+	and_or_scom(chip, 0x8008D00006010C3F + offset,
+		    ~(PPC_BITMASK(48, 55) | PPC_BITMASK(56, 63)),
+		    PPC_PLACE(0x66, 48, 8) | PPC_PLACE(0x44, 56, 8));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE27_EO_PG
+	// 48 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_RC_ENABLE_CTLE_1ST_LATCH_OFFSET_CAL_ON
+	or_scom(chip, 0x8009700006010C3F + offset, PPC_BIT(48));
+
+	// P9A_XBUS_0_RX[01]_RX_ID2_PG
+	and_or_scom(chip, 0x8009800006010C3F + offset,
+		    ~(PPC_BITMASK(49, 55) | PPC_BITMASK(57, 63)),
+		    PPC_PLACE(0x00, 49, 7) | PPC_PLACE(0x10, 57, 7));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE1_E_PG
+	// 48 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_MASTER_MODE_MASTER
+	// 57 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_FENCE_FENCED
+	// 58 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_PDWN_LITE_DISABLE_ON
+	or_scom(chip, 0x8009900006010C3F + offset,
+		(xbus_master_mode ? PPC_BIT(48) : 0) | PPC_BIT(57) | PPC_BIT(58));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE2_E_PG
+	and_or_scom(chip, 0x8009980006010C3F + offset,
+		    ~PPC_BITMASK(48, 52), PPC_PLACE(0x01, 48, 5));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE3_E_PG
+	and_or_scom(chip, 0x8009A00006010C3F + offset,
+		    ~PPC_BITMASK(48, 51), PPC_PLACE(0xB, 48, 4));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE5_E_PG
+	and_or_scom(chip, 0x8009B00006010C3F + offset,
+		    ~PPC_BITMASK(52, 55), PPC_PLACE(0x1, 52, 4));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE6_E_PG
+	and_or_scom(chip, 0x8009B80006010C3F + offset,
+		    ~(PPC_BITMASK(48, 54) | PPC_BITMASK(55, 61)),
+		    PPC_PLACE(0x11, 48, 7) | PPC_PLACE(0x11, 55, 7));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE8_E_PG
+	// 55-58 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DYN_RPR_ERR_CNTR1_DURATION_TAP5
+	and_or_scom(chip, 0x8009C80006010C3F + offset,
+		    ~(PPC_BITMASK(48, 54) | PPC_BITMASK(55, 58) | PPC_BITMASK(61, 63)),
+		    PPC_PLACE(0xF, 48, 7) | PPC_PLACE(0x5, 55, 4) | PPC_PLACE(0x5, 61, 3));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE9_E_PG
+	// 55-58 - IOF1_RX_RX0_RXCTL_CTL_REGS_RX_CTL_REGS_RX_DYN_RPR_ERR_CNTR2_DURATION_TAP5
+	and_or_scom(chip, 0x8009D00006010C3F + offset,
+		    ~(PPC_BITMASK(48, 54) | PPC_BITMASK(55, 58)),
+		    PPC_PLACE(0x3F, 48, 7) | PPC_PLACE(0x5, 55, 4));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE11_E_PG
+	and_scom(chip, 0x8009E00006010C3F + offset, ~PPC_BITMASK(48, 63));
+
+	// P9A_XBUS_0_RX[01]_RX_CTL_MODE12_E_PG
+	and_or_scom(chip, 0x8009E80006010C3F + offset,
+		    ~PPC_BITMASK(48, 55), PPC_PLACE(0x7F, 48, 8));
+
+	// P9A_XBUS_0_RX[01]_RX_GLBSM_SPARE_MODE_PG
+	// 50 - IOF1_RX_RX0_RXCTL_GLBSM_REGS_RX_PG_GLBSM_SPARE_MODE_2_ON
+	// 56 - IOF1_RX_RX0_RXCTL_GLBSM_REGS_RX_DESKEW_BUMP_AFTER_AFTER
+	or_scom(chip, 0x800A800006010C3F + offset, PPC_BIT(50) | PPC_BIT(56));
+
+	// P9A_XBUS_0_RX[01]_RX_GLBSM_CNTL3_EO_PG
+	and_or_scom(chip, 0x800AE80006010C3F + offset,
+		    ~PPC_BITMASK(56, 57), PPC_PLACE(0x2, 56, 2));
+
+	// P9A_XBUS_0_RX[01]_RX_GLBSM_MODE1_EO_PG
+	and_or_scom(chip, 0x800AF80006010C3F + offset,
+		    ~(PPC_BITMASK(48, 51) | PPC_BITMASK(52, 55)),
+		    PPC_PLACE(0xC, 48, 4) | PPC_PLACE(0xC, 52, 4));
+
+	// P9A_XBUS_0_RX[01]_RX_DATASM_SPARE_MODE_PG
+	// 60 - IOF1_RX_RX0_RXCTL_DATASM_DATASM_REGS_RX_CTL_DATASM_CLKDIST_PDWN_OFF
+	and_scom(chip, 0x800B800006010C3F + offset, ~PPC_BIT(60));
+
+	// P9A_XBUS_0_TX[01]_TX_SPARE_MODE_PG
+	and_scom(chip, 0x800C040006010C3F + offset, ~PPC_BITMASK(56, 57));
+
+	// P9A_XBUS_0_TX[01]_TX_ID1_PG
+	and_or_scom(chip, 0x800C0C0006010C3F + offset,
+		    ~PPC_BITMASK(48, 53),
+		    PPC_PLACE((group == 0 ? 0x00 : 0x01), 48, 6));
+
+	// P9A_XBUS_0_TX[01]_TX_CTL_MODE1_EO_PG
+	// 48 - IOF1_TX_WRAP_TX0_TXCTL_CTL_REGS_TX_CTL_REGS_TX_CLKDIST_PDWN_OFF
+	// 59 - IOF1_TX_WRAP_TX0_TXCTL_CTL_REGS_TX_CTL_REGS_TX_PDWN_LITE_DISABLE_ON
+	and_or_scom(chip, 0x800C140006010C3F + offset,
+		    ~(PPC_BIT(48) | PPC_BITMASK(53, 57) | PPC_BIT(59)),
+		    PPC_PLACE(0x01, 53, 5) | PPC_BIT(59));
+
+	// P9A_XBUS_0_TX[01]_TX_CTL_MODE2_EO_PG
+	and_or_scom(chip, 0x800C1C0006010C3F + offset,
+		    ~PPC_BITMASK(56, 62), PPC_PLACE(0x11, 56, 7));
+
+	// P9A_XBUS_0_TX[01]_TX_CTL_CNTLG1_EO_PG
+	// 48-49 - IOF1_TX_WRAP_TX0_TXCTL_CTL_REGS_TX_CTL_REGS_TX_DRV_CLK_PATTERN_GCRMSG_DRV_0S
+	and_scom(chip, 0x800C240006010C3F + offset, ~PPC_BITMASK(48, 49));
+
+	// P9A_XBUS_0_TX[01]_TX_ID2_PG
+	and_or_scom(chip, 0x800C840006010C3F + offset,
+		    ~(PPC_BITMASK(49, 55) | PPC_BITMASK(57, 63)),
+		    PPC_PLACE(0x0, 49, 7) | PPC_PLACE(0x10, 57, 7));
+
+	// P9A_XBUS_0_TX[01]_TX_CTL_MODE1_E_PG
+	// 55-57 - IOF1_TX_WRAP_TX0_TXCTL_CTL_REGS_TX_CTL_REGS_TX_DYN_RECAL_INTERVAL_TIMEOUT_SEL_TAP5
+	// 58-59 - IOF1_TX_WRAP_TX0_TXCTL_CTL_REGS_TX_CTL_REGS_TX_DYN_RECAL_STATUS_RPT_TIMEOUT_SEL_TAP1
+	and_or_scom(chip, 0x800C8C0006010C3F + offset,
+		    ~(PPC_BITMASK(55, 57) | PPC_BITMASK(58, 59)),
+		    PPC_PLACE(0x5, 55, 3) | PPC_PLACE(0x1, 58, 2));
+
+	// P9A_XBUS_0_TX[01]_TX_CTL_MODE2_E_PG
+	and_scom(chip, 0x800CEC0006010C3F + offset, ~PPC_BITMASK(48, 63));
+
+	// P9A_XBUS_0_TX[01]_TX_CTL_MODE3_E_PG
+	and_or_scom(chip, 0x800CF40006010C3F + offset,
+		    ~PPC_BITMASK(48, 55), PPC_PLACE(0x7F, 48, 8));
+
+	// P9A_XBUS_0_TX[01]_TX_CTLSM_MODE1_EO_PG
+	// 59 - IOF1_TX_WRAP_TX0_TXCTL_TX_CTL_SM_REGS_TX_FFE_BOOST_EN_ON
+	or_scom(chip, 0x800D2C0006010C3F + offset, PPC_BIT(59));
+
+	// P9A_XBUS_0_TX_IMPCAL_P_4X_PB (identical for both groups)
+	and_or_scom(chip, 0x800F1C0006010C3F,
+		    ~PPC_BITMASK(48, 54), PPC_PLACE(0x0E, 48, 5));
+}
+
+static void set_msb_swap(uint8_t chip, int group)
+{
+	enum {
+		TX_CTL_MODE1_EO_PG = 0x800C140006010C3F,
+		EDIP_TX_MSBSWAP = 58,
+	};
+
+	const uint64_t offset = group * 0x2000000000;
+
+	/* ATTR_EI_BUS_TX_MSBSWAP seems to be 0x80 which is GROUP_0_SWAP */
+	if (group == 0)
+		or_scom(chip, TX_CTL_MODE1_EO_PG + offset, PPC_BIT(EDIP_TX_MSBSWAP));
+	else
+		and_scom(chip, TX_CTL_MODE1_EO_PG + offset, ~PPC_BIT(EDIP_TX_MSBSWAP));
+}
+
+static void xbus_scominit(int group)
+{
+	enum {
+		PU_PB_CENT_SM0_PB_CENT_FIR_REG = 0x05011C00,
+
+		XBUS_PHY_FIR_ACTION0 = 0x0000000000000000ULL,
+		XBUS_FIR_ACTION0_REG = 0x06010C06,
+		XBUS_PHY_FIR_ACTION1 = 0x2068680000000000ULL,
+		XBUS_FIR_ACTION1_REG = 0x06010C07,
+		XBUS_PHY_FIR_MASK    = 0xDF9797FFFFFFC000ULL,
+		XBUS_FIR_MASK_REG    = 0x06010C03,
+
+		EDIP_RX_IORESET = 0x8009F80006010C3F,
+		EDIP_TX_IORESET = 0x800C9C0006010C3F,
+	};
+
+	const uint64_t offset = group * 0x2000000000;
+
+	/* Assert IO reset to power-up bus endpoint logic */
+	or_scom(0, EDIP_RX_IORESET + offset, PPC_BIT(52));
+	or_scom(1, EDIP_RX_IORESET + offset, PPC_BIT(52));
+	udelay(50);
+	or_scom(0, EDIP_TX_IORESET + offset, PPC_BIT(48));
+	or_scom(1, EDIP_TX_IORESET + offset, PPC_BIT(48));
+	udelay(50);
+
+	set_msb_swap(/*chip=*/0, group);
+	set_msb_swap(/*chip=*/1, group);
+
+	xbus_scom(/*chip=*/0, group);
+	xbus_scom(/*chip=*/1, group);
+
+	/* PU_PB_CENT_SM0_PB_CENT_FIR_MASK_REG_SPARE_13 */
+	if (!(get_scom(/*chip=*/0, PU_PB_CENT_SM0_PB_CENT_FIR_REG) & PPC_BIT(13))) {
+		put_scom(/*chip=*/0, XBUS_FIR_ACTION0_REG, XBUS_PHY_FIR_ACTION0);
+		put_scom(/*chip=*/0, XBUS_FIR_ACTION1_REG, XBUS_PHY_FIR_ACTION1);
+		put_scom(/*chip=*/0, XBUS_FIR_MASK_REG, XBUS_PHY_FIR_MASK);
+	}
+}
+
+void istep_8_10(uint8_t chips)
+{
+	printk(BIOS_EMERG, "starting istep 8.10\n");
+	report_istep(8,10);
+
+	if (chips != 0x01) {
+		xbus_scominit(/*group=*/0);
+		xbus_scominit(/*group=*/1);
+	}
+
+	printk(BIOS_EMERG, "ending istep 8.10\n");
+}

--- a/src/soc/ibm/power9/istep_8_11.c
+++ b/src/soc/ibm/power9/istep_8_11.c
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/power/istep_8.h>
+
+#include <console/console.h>
+#include <cpu/power/scom.h>
+
+static void xbus_enable_ridi(uint8_t chip)
+{
+	enum {
+		PERV_NET_CTRL0 = 0x060F0040,
+		PERV_NET_CTRL0_WOR = 0x060F0042,
+	};
+
+	/* Getting NET_CTRL0 register value and checking its CHIPLET_ENABLE bit */
+	if (get_scom(chip, PERV_NET_CTRL0) & PPC_BIT(0)) {
+		/* Enable Recievers, Drivers DI1 & DI2 */
+		uint64_t val = 0;
+		val |= PPC_BIT(19); // NET_CTRL0.RI_N = 1
+		val |= PPC_BIT(20); // NET_CTRL0.DI1_N = 1
+		val |= PPC_BIT(21); // NET_CTRL0.DI2_N = 1
+		put_scom(chip, PERV_NET_CTRL0_WOR, val);
+	}
+}
+
+void istep_8_11(uint8_t chips)
+{
+	printk(BIOS_EMERG, "starting istep 8.11\n");
+	report_istep(8,11);
+
+	if (chips != 0x01) {
+		xbus_enable_ridi(/*chip=*/0);
+		xbus_enable_ridi(/*chip=*/1);
+	}
+
+	printk(BIOS_EMERG, "ending istep 8.11\n");
+}

--- a/src/soc/ibm/power9/istep_8_9.c
+++ b/src/soc/ibm/power9/istep_8_9.c
@@ -1,0 +1,388 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/power/istep_8.h>
+
+#include <console/console.h>
+#include <cpu/power/powerbus.h>
+#include <cpu/power/scom.h>
+
+#include "sbeio.h"
+#include "scratch.h"
+
+#include "fsi.h"
+
+/*
+ * This code omits initialization of OBus which isn't present. It also assumes
+ * there is only one XBus (X1). Both of these statements are true for Nimbus
+ * Sforza.
+ */
+
+/* Updates address that targets XBus chiplet to use specified XBus link number.
+ * Does nothing to non-XBus addresses. */
+static uint64_t xbus_addr(uint8_t xbus, uint64_t addr)
+{
+	enum {
+		XBUS_COUNT = 0x3,		// number of XBus links
+		XB_IOX_0_RING_ID = 0x3,		// IOX_0
+		XB_PBIOX_0_RING_ID = 0x6,	// PBIOX_0
+	};
+
+	uint8_t ring = (addr >> 10) & 0xF;
+	uint8_t chiplet = (addr >> 24) & 0x3F;
+
+	if (chiplet != XB_CHIPLET_ID)
+		return addr;
+
+	if (ring >= XB_IOX_0_RING_ID && ring < XB_IOX_0_RING_ID + XBUS_COUNT)
+		ring = XB_IOX_0_RING_ID + xbus;
+	else if (ring >= XB_PBIOX_0_RING_ID && ring < XB_PBIOX_0_RING_ID + XBUS_COUNT)
+		ring = XB_PBIOX_0_RING_ID + xbus;
+
+	addr &= ~PPC_BITMASK(50, 53);
+	addr |= PPC_PLACE(ring, 50, 4);
+
+	return addr;
+}
+
+void put_scom(uint8_t chip, uint64_t addr, uint64_t data)
+{
+	addr = xbus_addr(/*xbus=*/1, addr);
+
+	if (chip == 0)
+		write_scom(addr, data);
+	else
+		write_sbe_scom(chip, addr, data);
+}
+
+uint64_t get_scom(uint8_t chip, uint64_t addr)
+{
+	addr = xbus_addr(/*xbus=*/1, addr);
+
+	if (chip == 0)
+		return read_scom(addr);
+	else
+		return read_sbe_scom(chip, addr);
+}
+
+static void p9_fbc_no_hp_scom(uint8_t chip)
+{
+	enum {
+		PB_WEST_MODE             = 0x501180A,
+		PB_CENT_MODE             = 0x5011C0A,
+		PB_CENT_GP_CMD_RATE_DP0  = 0x5011C26,
+		PB_CENT_GP_CMD_RATE_DP1  = 0x5011C27,
+		PB_CENT_RGP_CMD_RATE_DP0 = 0x5011C28,
+		PB_CENT_RGP_CMD_RATE_DP1 = 0x5011C29,
+		PB_CENT_SP_CMD_RATE_DP0  = 0x5011C2A,
+		PB_CENT_SP_CMD_RATE_DP1  = 0x5011C2B,
+		PB_EAST_MODE             = 0x501200A,
+	};
+
+	const uint64_t scratch_reg6 = read_scom(MBOX_SCRATCH_REG1 + 5);
+	/* ATTR_PROC_FABRIC_PUMP_MODE, it's either node or group pump mode */
+	const bool node_pump_mode = !(scratch_reg6 & PPC_BIT(MBOX_SCRATCH_REG6_GROUP_PUMP_MODE));
+
+	/* Assuming that ATTR_PROC_EPS_TABLE_TYPE = EPS_TYPE_LE in talos.xml is always correct */
+	const bool is_flat_8 = false;
+
+	/*
+	 * ATTR_PROC_FABRIC_X_LINKS_CNFG
+	 * We have one XBus, so I guess this is 1, otherwise need to dig into
+	 * related code in Hostboot where link configuration is generated.
+	 */
+	const int num_x_links_cfg = 1;
+
+	/* Power Bus PB West Mode Configuration Register */
+	uint64_t pb_west_mode = get_scom(chip, PB_WEST_MODE);
+	/* Power Bus PB CENT Mode Register */
+	uint64_t pb_cent_mode = get_scom(chip, PB_CENT_MODE);
+	/* Power Bus PB CENT GP command RATE DP0 Register */
+	uint64_t pb_cent_gp_cmd_rate_dp0 = get_scom(chip, PB_CENT_GP_CMD_RATE_DP0);
+	/* Power Bus PB CENT GP command RATE DP1 Register */
+	uint64_t pb_cent_gp_cmd_rate_dp1 = get_scom(chip, PB_CENT_GP_CMD_RATE_DP1);
+	/* Power Bus PB CENT RGP command RATE DP0 Register */
+	uint64_t pb_cent_rgp_cmd_rate_dp0 = get_scom(chip, PB_CENT_RGP_CMD_RATE_DP0);
+	/* Power Bus PB CENT RGP command RATE DP1 Register */
+	uint64_t pb_cent_rgp_cmd_rate_dp1 = get_scom(chip, PB_CENT_RGP_CMD_RATE_DP1);
+	/* Power Bus PB CENT SP command RATE DP0 Register */
+	uint64_t pb_cent_sp_cmd_rate_dp0 = get_scom(chip, PB_CENT_SP_CMD_RATE_DP0);
+	/* Power Bus PB CENT SP command RATE DP1 Register */
+	uint64_t pb_cent_sp_cmd_rate_dp1 = get_scom(chip, PB_CENT_SP_CMD_RATE_DP1);
+	/* Power Bus PB East Mode Configuration Register */
+	uint64_t pb_east_mode = get_scom(chip, PB_EAST_MODE);
+
+	if (!node_pump_mode || num_x_links_cfg == 0) {
+		pb_cent_gp_cmd_rate_dp0 = 0;
+		pb_cent_gp_cmd_rate_dp1 = 0;
+	} else if (node_pump_mode && num_x_links_cfg > 0 && num_x_links_cfg < 3) {
+		pb_cent_gp_cmd_rate_dp0 = 0x030406171C243448;
+		pb_cent_gp_cmd_rate_dp1 = 0x040508191F283A50;
+	} else if (node_pump_mode && num_x_links_cfg > 2) {
+		pb_cent_gp_cmd_rate_dp0 = 0x0304062832405C80;
+		pb_cent_gp_cmd_rate_dp1 = 0x0405082F3B4C6D98;
+	}
+
+	if (!node_pump_mode && num_x_links_cfg == 0) {
+		pb_cent_rgp_cmd_rate_dp0 = 0;
+		pb_cent_rgp_cmd_rate_dp1 = 0;
+		pb_cent_sp_cmd_rate_dp0 = 0;
+		pb_cent_sp_cmd_rate_dp1 = 0;
+	} else if (!node_pump_mode && num_x_links_cfg > 0 && num_x_links_cfg < 3) {
+		pb_cent_rgp_cmd_rate_dp0 = 0x030406080A0C1218;
+		pb_cent_rgp_cmd_rate_dp1 = 0x040508080A0C1218;
+		pb_cent_sp_cmd_rate_dp0 = 0x030406080A0C1218;
+		pb_cent_sp_cmd_rate_dp1 = 0x030406080A0C1218;
+	} else if ((!node_pump_mode && num_x_links_cfg == 3) ||
+		   (node_pump_mode && num_x_links_cfg == 0)) {
+		pb_cent_rgp_cmd_rate_dp0 = 0x0304060D10141D28;
+		pb_cent_rgp_cmd_rate_dp1 = 0x0405080D10141D28;
+		pb_cent_sp_cmd_rate_dp0 = 0x05070A0D10141D28;
+		pb_cent_sp_cmd_rate_dp1 = 0x05070A0D10141D28;
+	} else if ((!node_pump_mode && is_flat_8) ||
+		   (node_pump_mode && num_x_links_cfg > 0 && num_x_links_cfg < 3)) {
+		pb_cent_rgp_cmd_rate_dp0 = 0x030406171C243448;
+		pb_cent_rgp_cmd_rate_dp1 = 0x040508191F283A50;
+		pb_cent_sp_cmd_rate_dp0 = 0x080C12171C243448;
+		pb_cent_sp_cmd_rate_dp1 = 0x0A0D14191F283A50;
+	} else if (node_pump_mode && num_x_links_cfg > 2) {
+		pb_cent_rgp_cmd_rate_dp0 = 0x0304062832405C80;
+		pb_cent_rgp_cmd_rate_dp1 = 0x0405082F3B4C6D98;
+		pb_cent_sp_cmd_rate_dp0 = 0x08141F2832405C80;
+		pb_cent_sp_cmd_rate_dp1 = 0x0A18252F3B4C6D98;
+	}
+
+	if (num_x_links_cfg == 0)
+		pb_east_mode |= 0x0300000000000000;
+	else
+		pb_east_mode &= 0xF1FFFFFFFFFFFFFF;
+
+	if (node_pump_mode && is_flat_8) {
+		pb_west_mode &= 0xFFFF0003FFFFFFFF;
+		pb_west_mode |= 0x00003E8000000000;
+
+		pb_cent_mode &= 0xFFFF0003FFFFFFFF;
+		pb_cent_mode |= 0x00003E8000000000;
+
+		pb_east_mode &= 0xFFFF0003FFFFFFFF;
+		pb_east_mode |= 0x00003E8000000000;
+	} else {
+		pb_west_mode &= 0xFFFF0003FFFFFFFF;
+		pb_west_mode |= 0x00007EFC00000000;
+
+		pb_cent_mode &= 0xFFFF0003FFFFFFFF;
+		pb_cent_mode |= 0x00007EFC00000000;
+
+		pb_east_mode &= 0xFFFF0003FFFFFFFF;
+		pb_east_mode |= 0x00007EFC00000000;
+	}
+
+	pb_west_mode &= 0xF7FFFFFFFFFFFFFF;
+
+	pb_west_mode &= 0xFFFFFFFC0FFFFFFF;
+	pb_west_mode |= 0x00000002A0000000;
+
+	pb_cent_mode &= 0xFFFFFFFC0FFFFFFF;
+	pb_cent_mode |= 0x00000002A0000000;
+
+	pb_east_mode &= 0xFFFFFFFC0FFFFFFF;
+	pb_east_mode |= 0x00000002A0000000;
+
+	put_scom(chip, PB_WEST_MODE, pb_west_mode);
+	put_scom(chip, PB_CENT_MODE, pb_cent_mode);
+	put_scom(chip, PB_CENT_GP_CMD_RATE_DP0, pb_cent_gp_cmd_rate_dp0);
+	put_scom(chip, PB_CENT_GP_CMD_RATE_DP1, pb_cent_gp_cmd_rate_dp1);
+	put_scom(chip, PB_CENT_RGP_CMD_RATE_DP0, pb_cent_rgp_cmd_rate_dp0);
+	put_scom(chip, PB_CENT_RGP_CMD_RATE_DP1, pb_cent_rgp_cmd_rate_dp1);
+	put_scom(chip, PB_CENT_SP_CMD_RATE_DP0, pb_cent_sp_cmd_rate_dp0);
+	put_scom(chip, PB_CENT_SP_CMD_RATE_DP1, pb_cent_sp_cmd_rate_dp1);
+	put_scom(chip, PB_EAST_MODE, pb_east_mode);
+}
+
+static void p9_fbc_ioe_tl_scom(uint8_t chip)
+{
+	enum {
+		PB_FP01_CFG              = 0x501340A,
+		PB_FP23_CFG              = 0x501340B,
+		PB_FP45_CFG              = 0x501340C,
+		PB_ELINK_DATA_23_CFG_REG = 0x5013411,
+		PB_ELINK_DATA_45_CFG_REG = 0x5013412,
+		PB_MISC_CFG              = 0x5013423,
+		PB_TRACE_CFG             = 0x5013424,
+	};
+
+	/*
+	 * We only support one XBus with
+	 *     ATTR_PROC_FABRIC_X_ATTACHED_CHIP_CNFG = { false, true, false }
+	 * Meaning that X1 is present and X0 and X2 aren't (from logs).
+	 * Should we determine link number dynamically?
+	 */
+
+	const uint64_t pb_freq_mhz = powerbus_cfg()->fabric_freq;
+
+	const uint64_t dd2_lo_limit_n = pb_freq_mhz * 82;
+
+	/* Processor bus Electrical Framer/Parser 01 configuration register */
+	uint64_t pb_fp01_cfg = get_scom(chip, PB_FP01_CFG);
+	/* Power Bus Electrical Framer/Parser 23 Configuration Register */
+	uint64_t pb_fp23_cfg = get_scom(chip, PB_FP23_CFG);
+	/* Power Bus Electrical Framer/Parser 45 Configuration Register */
+	uint64_t pb_fp45_cfg = get_scom(chip, PB_FP45_CFG);
+	/* Power Bus Electrical Link Data Buffer 23 Configuration Register */
+	uint64_t pb_elink_data_23_cfg_reg = get_scom(chip, PB_ELINK_DATA_23_CFG_REG);
+	/* Power Bus Electrical Link Data Buffer 45 Configuration Register */
+	uint64_t pb_elink_data_45_cfg_reg = get_scom(chip, PB_ELINK_DATA_45_CFG_REG);
+	/* Power Bus Electrical Miscellaneous Configuration Register */
+	uint64_t pb_misc_cfg = get_scom(chip, PB_MISC_CFG);
+	/* Power Bus Electrical Link Trace Configuration Register */
+	uint64_t pb_trace_cfg = get_scom(chip, PB_TRACE_CFG);
+
+	pb_fp01_cfg |= 0x0000084000000840;
+
+	pb_fp45_cfg |= 0x0000084000000840;
+
+	PPC_INSERT(pb_trace_cfg, 0x4, 16, 4);
+	PPC_INSERT(pb_trace_cfg, 0x4, 24, 4);
+	PPC_INSERT(pb_trace_cfg, 0x1, 20, 4);
+	PPC_INSERT(pb_trace_cfg, 0x1, 28, 4);
+
+	PPC_INSERT(pb_fp23_cfg, 0x15 - (dd2_lo_limit_n / 20000), 4, 8);
+	PPC_INSERT(pb_fp23_cfg, 0x15 - (dd2_lo_limit_n / 20000), 36, 8);
+
+	PPC_INSERT(pb_fp23_cfg, 0x01, 22, 2);
+	PPC_INSERT(pb_fp23_cfg, 0x20, 12, 8);
+	PPC_INSERT(pb_fp23_cfg, 0x00, 20, 1);
+	PPC_INSERT(pb_fp23_cfg, 0x00, 25, 1);
+	PPC_INSERT(pb_fp23_cfg, 0x20, 44, 8);
+	PPC_INSERT(pb_fp23_cfg, 0x00, 52, 1);
+	PPC_INSERT(pb_fp23_cfg, 0x00, 57, 1);
+	PPC_INSERT(pb_elink_data_23_cfg_reg, 0x1F, 24, 5);
+	PPC_INSERT(pb_elink_data_23_cfg_reg, 0x40, 1, 7);
+	PPC_INSERT(pb_elink_data_23_cfg_reg, 0x40, 33, 7);
+	PPC_INSERT(pb_elink_data_23_cfg_reg, 0x3C, 9, 7);
+	PPC_INSERT(pb_elink_data_23_cfg_reg, 0x3C, 41, 7);
+	PPC_INSERT(pb_elink_data_23_cfg_reg, 0x3C, 17, 7);
+	PPC_INSERT(pb_elink_data_23_cfg_reg, 0x3C, 49, 7);
+
+	pb_misc_cfg &= ~PPC_BIT(0);
+	pb_misc_cfg |= PPC_BIT(1);
+	pb_misc_cfg &= ~PPC_BIT(2);
+
+	put_scom(chip, PB_FP01_CFG, pb_fp01_cfg);
+	put_scom(chip, PB_FP23_CFG, pb_fp23_cfg);
+	put_scom(chip, PB_FP45_CFG, pb_fp45_cfg);
+	put_scom(chip, PB_ELINK_DATA_23_CFG_REG, pb_elink_data_23_cfg_reg);
+	put_scom(chip, PB_ELINK_DATA_45_CFG_REG, pb_elink_data_45_cfg_reg);
+	put_scom(chip, PB_MISC_CFG, pb_misc_cfg);
+	put_scom(chip, PB_TRACE_CFG, pb_trace_cfg);
+}
+
+static void p9_fbc_ioe_dl_scom(uint8_t chip)
+{
+	enum {
+		IOEL_CONFIG = 0x601180A,
+		IOEL_REPLAY_THRESHOLD = 0x6011818,
+		IOEL_SL_ECC_THRESHOLD = 0x6011819,
+	};
+
+	/* ELL Configuration Register */
+	uint64_t ioel_config = get_scom(chip, IOEL_CONFIG);
+	/* ELL Replay Threshold Register */
+	uint64_t ioel_replay_threshold = get_scom(chip, IOEL_REPLAY_THRESHOLD);
+	/* ELL SL ECC Threshold Register */
+	uint64_t ioel_sl_ecc_threshold = get_scom(chip, IOEL_SL_ECC_THRESHOLD);
+
+	/* ATTR_LINK_TRAIN == fapi2::ENUM_ATTR_LINK_TRAIN_BOTH (from logs) */
+	ioel_config |= 0x8000000000000000;
+	ioel_config &= 0xFFEFFFFFFFFFFFFF;
+	ioel_config |= 0x280F000F00000000;
+
+	ioel_sl_ecc_threshold |= 0x00E0000000000000;
+
+	ioel_replay_threshold &= 0x0FFFFFFFFFFFFFFF;
+	ioel_replay_threshold |= 0x6FE0000000000000;
+
+	ioel_sl_ecc_threshold &= 0x7FFFFFFFFFFFFFFF;
+	ioel_sl_ecc_threshold |= 0x7F00000000000000;
+
+	put_scom(chip, IOEL_CONFIG, ioel_config);
+	put_scom(chip, IOEL_REPLAY_THRESHOLD, ioel_replay_threshold);
+	put_scom(chip, IOEL_SL_ECC_THRESHOLD, ioel_sl_ecc_threshold);
+}
+
+static void chiplet_fabric_scominit(uint8_t chip)
+{
+	enum {
+		PU_PB_CENT_SM0_IR_REG = 0x5011C00,
+		PU_PB_CENT_SM0_IR_MASK_REG_SPARE_13 = PPC_BIT(13),
+
+		PU_PB_IOE_FIR_ACTION0_REG = 0x05013406,
+		FBC_IOE_TL_FIR_ACTION0 = 0x0000000000000000,
+
+		PU_PB_IOE_FIR_ACTION1_REG = 0x05013407,
+		FBC_IOE_TL_FIR_ACTION1 = 0x0049000000000000,
+
+		PU_PB_IOE_FIR_MASK_REG = 0x05013403,
+		FBC_IOE_TL_FIR_MASK = 0xFF24F0303FFFF11,
+		FBC_IOE_TL_FIR_MASK_X0_NF = 0x00C00C0C00000880,
+		FBC_IOE_TL_FIR_MASK_X2_NF = 0x000300C0C0000220,
+
+		XBUS_LL0_IOEL_FIR_ACTION0_REG = 0x06011806,
+		FBC_IOE_DL_FIR_ACTION0 = 0x0000000000000000,
+
+		XBUS_LL0_IOEL_FIR_ACTION1_REG = 0x06011807,
+		FBC_IOE_DL_FIR_ACTION1 = 0x0303C00000001FFC,
+
+		XBUS_LL0_IOEL_FIR_MASK_REG = 0x06011803,
+		FBC_IOE_DL_FIR_MASK = 0xFCFC3FFFFFFFE003,
+	};
+
+	bool init_firs;
+	uint64_t fbc_cent_fir;
+
+	/* Apply FBC non-hotplug initfile */
+	p9_fbc_no_hp_scom(chip);
+
+	/* Setup IOE (XBUS FBC IO) TL SCOMs */
+	p9_fbc_ioe_tl_scom(chip);
+
+	/* TL/DL FIRs are configured by us only if not already setup by SBE */
+	fbc_cent_fir = get_scom(chip, PU_PB_CENT_SM0_IR_REG);
+	init_firs = !(fbc_cent_fir & PU_PB_CENT_SM0_IR_MASK_REG_SPARE_13);
+
+	if (init_firs) {
+		uint64_t fir_mask;
+
+		put_scom(chip, PU_PB_IOE_FIR_ACTION0_REG, FBC_IOE_TL_FIR_ACTION0);
+		put_scom(chip, PU_PB_IOE_FIR_ACTION1_REG, FBC_IOE_TL_FIR_ACTION1);
+
+		fir_mask = FBC_IOE_TL_FIR_MASK
+			 | FBC_IOE_TL_FIR_MASK_X0_NF
+			 | FBC_IOE_TL_FIR_MASK_X2_NF;
+		put_scom(chip, PU_PB_IOE_FIR_MASK_REG, fir_mask);
+	}
+
+	/* Setup IOE (XBUS FBC IO) DL SCOMs */
+	p9_fbc_ioe_dl_scom(chip);
+
+	if (init_firs) {
+		put_scom(chip, XBUS_LL0_IOEL_FIR_ACTION0_REG, FBC_IOE_DL_FIR_ACTION0);
+		put_scom(chip, XBUS_LL0_IOEL_FIR_ACTION1_REG, FBC_IOE_DL_FIR_ACTION1);
+		put_scom(chip, XBUS_LL0_IOEL_FIR_MASK_REG, FBC_IOE_DL_FIR_MASK);
+	}
+}
+
+void istep_8_9(uint8_t chips)
+{
+	printk(BIOS_EMERG, "starting istep 8.9\n");
+	report_istep(8,9);
+
+	if (chips != 0x01) {
+		/* Not skipping master chip */
+		for (uint8_t chip = 0; chip < 8; chip++) {
+			if (chips & (1 << chip))
+				chiplet_fabric_scominit(chip);
+		}
+	}
+
+	printk(BIOS_EMERG, "ending istep 8.9\n");
+}

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -369,6 +369,7 @@ void main(void)
 	istep_8_3(chips);
 	istep_8_4(chips);
 	istep_8_9(chips);
+	istep_8_10(chips);
 
 	istep_10_10(&phb_active_mask, iovalid_enable);
 	istep_10_12();

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -370,6 +370,7 @@ void main(void)
 	istep_8_4(chips);
 	istep_8_9(chips);
 	istep_8_10(chips);
+	istep_8_11(chips);
 
 	istep_10_10(&phb_active_mask, iovalid_enable);
 	istep_10_12();

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -368,6 +368,7 @@ void main(void)
 	istep_8_2(chips);
 	istep_8_3(chips);
 	istep_8_4(chips);
+	istep_8_9(chips);
 
 	istep_10_10(&phb_active_mask, iovalid_enable);
 	istep_10_12();

--- a/src/soc/ibm/power9/sbeio.c
+++ b/src/soc/ibm/power9/sbeio.c
@@ -1,0 +1,234 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include "sbeio.h"
+
+#include <console/console.h>
+#include <delay.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "fsi.h"
+
+enum fifo_regs {
+	SBE_FIFO_UPFIFO_DATA_IN    = 0x00002400,
+	SBE_FIFO_UPFIFO_STATUS     = 0x00002404,
+	SBE_FIFO_UPFIFO_SIG_EOT    = 0x00002408,
+	SBE_FIFO_UPFIFO_REQ_RESET  = 0x0000240C,
+	SBE_FIFO_DNFIFO_DATA_OUT   = 0x00002440,
+	SBE_FIFO_DNFIFO_STATUS     = 0x00002444,
+	SBE_FIFO_DNFIFO_RESET      = 0x00002450,
+	SBE_FIFO_DNFIFO_ACK_EOT    = 0x00002454,
+	SBE_FIFO_DNFIFO_MAX_TSFR   = 0x00002458,
+};
+
+enum {
+	SBE_FIFO_CLASS_SCOM_ACCESS = 0xA2,
+	SBE_FIFO_CMD_GET_SCOM = 0x01,
+	SBE_FIFO_CMD_PUT_SCOM = 0x02,
+
+	FSB_FIFO_SIG_EOT = 0x80000000,
+	MAX_FIFO_TIMEOUT_US = 2 * 1000 * 1000, // Hostboot waits up to 90s!
+
+	FIFO_STATUS_MAGIC = 0xC0DE,
+};
+
+struct get_scom_request_t {
+	uint32_t word_count;	// size in uint32_t (4)
+	uint16_t reserved;	// 0
+	uint8_t  cmd_class;	// SBE_FIFO_CLASS_SCOM_ACCESS
+	uint8_t  cmd;		// SBE_FIFO_CMD_GET_SCOM
+	uint64_t addr;
+} __attribute__((packed));
+
+struct put_scom_request_t {
+	uint32_t word_count;	// size in uint32_t (6)
+	uint16_t reserved;	// 0
+	uint8_t  cmd_class;	// SBE_FIFO_CLASS_SCOM_ACCESS
+	uint8_t  cmd;		// SBE_FIFO_CMD_PUT_SCOM
+	uint64_t addr;
+	uint64_t data;
+} __attribute__((packed));
+
+/* This structure is part of every response */
+struct status_hdr_t {
+	uint16_t  magic;	// FIFO_STATUS_MAGIC
+	uint8_t   cmd_class;
+	uint8_t   cmd;
+	uint16_t  primary_status;
+	uint16_t  secondary_status;
+} __attribute__((packed));
+
+static void fifo_push(uint8_t chip, uint32_t addr, uint32_t data)
+{
+	enum { UPFIFO_STATUS_FIFO_FULL = 0x00200000 };
+
+	uint64_t elapsed_time_us = 0;
+
+	while (true) {
+		uint32_t status = read_fsi(chip, SBE_FIFO_UPFIFO_STATUS);
+		if (!(status & UPFIFO_STATUS_FIFO_FULL))
+			break;
+
+		if (elapsed_time_us >= MAX_FIFO_TIMEOUT_US)
+			die("Timeout waiting for upstream SBE FIFO to be not full");
+
+		udelay(10);
+		elapsed_time_us += 10;
+	}
+
+	write_fsi(chip, addr, data);
+}
+
+static void write_request(uint8_t chip, const void *request, uint32_t word_count)
+{
+	const uint32_t *words = request;
+
+	/*
+	 * Ensure Downstream Max Transfer Counter is 0 since we have no need for
+	 * it and non-0 can cause protocol issues.
+	 */
+	write_fsi(chip, SBE_FIFO_DNFIFO_MAX_TSFR, 0x0);
+
+	for (uint32_t i = 0; i < word_count; i++)
+		fifo_push(chip, SBE_FIFO_UPFIFO_DATA_IN, words[i]);
+
+	/* Notify SBE that last word has been sent */
+	fifo_push(chip, SBE_FIFO_UPFIFO_SIG_EOT, FSB_FIFO_SIG_EOT);
+}
+
+/* Returns true when there is no more data to be read */
+static bool fifo_pop(uint8_t chip, uint32_t *data)
+{
+	enum {
+		DNFIFO_STATUS_DEQUEUED_EOT_FLAG = 0x00800000,
+		DNFIFO_STATUS_FIFO_EMPTY = 0x00100000,
+	};
+
+	uint64_t elapsed_time_us = 0;
+
+	while (true) {
+		uint32_t status = read_fsi(chip, SBE_FIFO_DNFIFO_STATUS);
+
+		/* If we're done receiving response */
+		if (status & DNFIFO_STATUS_DEQUEUED_EOT_FLAG)
+			return false;
+
+		/* If there is more data */
+		if (!(status & DNFIFO_STATUS_FIFO_EMPTY))
+			break;
+
+		if (elapsed_time_us >= MAX_FIFO_TIMEOUT_US) {
+			printk(BIOS_INFO, "Last downstream SBE status: 0x%08x\n", status);
+			die("Timeout waiting for downstream SBE FIFO to be not empty\n");
+		}
+
+		udelay(10);
+		elapsed_time_us += 10;
+	}
+
+	*data = read_fsi(chip, SBE_FIFO_DNFIFO_DATA_OUT);
+	return true;
+}
+
+static void read_response(uint8_t chip, void *response, uint32_t word_count)
+{
+	enum {
+		MSG_BUFFER_SIZE = 2048,
+
+		STATUS_SIZE_WORDS = sizeof(struct status_hdr_t) / sizeof(uint32_t),
+
+		SBE_PRI_OPERATION_SUCCESSFUL = 0x00,
+		SBE_SEC_OPERATION_SUCCESSFUL = 0x00,
+	};
+
+	/* Large enough to receive FFDC */
+	static uint32_t buffer[MSG_BUFFER_SIZE];
+
+	uint32_t idx;
+	uint32_t offset_idx;
+	uint32_t status_idx;
+	struct status_hdr_t *status_hdr;
+
+	uint32_t *words = response;
+
+	/*
+	 * Message Schema:
+	 *  |Return Data (optional)| Status Header | FFDC (optional)
+	 *  |Offset to Status Header (starting from EOT) | EOT |
+	 */
+
+	for (idx = 0; idx < MSG_BUFFER_SIZE; ++idx) {
+		if (!fifo_pop(chip, &buffer[idx]))
+			break;
+
+		if (idx < word_count)
+			words[idx] = buffer[idx];
+	}
+
+	if (idx == MSG_BUFFER_SIZE)
+		die("SBE IO response exceeded maximum allowed size\n");
+
+	/* Notify SBE that EOT has been received */
+	write_fsi(chip, SBE_FIFO_DNFIFO_ACK_EOT, FSB_FIFO_SIG_EOT);
+
+	/*
+	 * Final index for a minimum complete message (No return data and no FFDC):
+	 *  Word Length of status header + Length of Offset (1) + Length of EOT (1)
+	 */
+	if (idx < STATUS_SIZE_WORDS + 2) {
+		printk(BIOS_INFO, "Response length in words: 0x%08x\n", idx);
+		die("SBE IO response is too short\n");
+	}
+
+	/*
+	 * |offset to header| EOT marker | current insert pos | <- idx
+	 * The offset is how far to move back from from the EOT position to
+	 * to get the index of the Status Header.
+	 */
+	offset_idx = idx - 2;
+
+	/* Validate the offset to the status header */
+	if (buffer[offset_idx] - 1 > offset_idx)
+		die("SBE response offset is too large\n");
+	else if (buffer[offset_idx] < STATUS_SIZE_WORDS + 1)
+		die("SBE response offset is too small\n");
+
+	status_idx = offset_idx - (buffer[offset_idx] - 1);
+	status_hdr = (struct status_hdr_t *)&buffer[status_idx];
+
+	/* Check status for success */
+	if (status_hdr->magic != FIFO_STATUS_MAGIC ||
+	    status_hdr->primary_status != SBE_PRI_OPERATION_SUCCESSFUL ||
+	    status_hdr->secondary_status != SBE_SEC_OPERATION_SUCCESSFUL)
+		die("Invalid status in SBE IO response\n");
+}
+
+void write_sbe_scom(uint8_t chip, uint64_t addr, uint64_t data)
+{
+	struct put_scom_request_t request = {
+		.word_count = sizeof(request) / sizeof(uint32_t),
+		.cmd_class = SBE_FIFO_CLASS_SCOM_ACCESS,
+		.cmd = SBE_FIFO_CMD_PUT_SCOM,
+		.addr = addr,
+		.data = data,
+	};
+
+	write_request(chip, &request, request.word_count);
+	read_response(chip, NULL, 0);
+}
+
+uint64_t read_sbe_scom(uint8_t chip, uint64_t addr)
+{
+	uint64_t data;
+	struct get_scom_request_t request = {
+		.word_count = sizeof(request) / sizeof(uint32_t),
+		.cmd_class = SBE_FIFO_CLASS_SCOM_ACCESS,
+		.cmd = SBE_FIFO_CMD_GET_SCOM,
+		.addr = addr,
+	};
+
+	write_request(chip, &request, request.word_count);
+	read_response(chip, &data, sizeof(data) / sizeof(uint32_t));
+
+	return data;
+}

--- a/src/soc/ibm/power9/sbeio.h
+++ b/src/soc/ibm/power9/sbeio.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef __SOC_IBM_POWER9_SBEIO_H
+#define __SOC_IBM_POWER9_SBEIO_H
+
+#include <stdint.h>
+
+void write_sbe_scom(uint8_t chip, uint64_t addr, uint64_t data);
+uint64_t read_sbe_scom(uint8_t chip, uint64_t addr);
+
+#endif /* __SOC_IBM_POWER9_SBEIO_H */


### PR DESCRIPTION
Contains implementation of SBE SCOM and isteps 8.9-8.11. This only initializes XBus without fully configuring it for use, which seems to be responsibility of isteps 9.*

~~Comparing logs show that a couple of values in istep 8.10 differ from state CPU is in with Hostboot, but it's not clear if that's an issue and what might be causing the difference. Initialization of the second CPU should be identical up to that point.~~

Depends on #64 PR, and transitively on #57 and #56.