### PR TITLE
mb/clevo/tgl-u/acpi/mainboard.asl: remove BT power resource

### DIFF
--- a/src/mainboard/clevo/tgl-u/acpi/mainboard.asl
+++ b/src/mainboard/clevo/tgl-u/acpi/mainboard.asl
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <soc/gpio_soc_defs.h>
-
 #define EC_GPE_SLPB 0x6B // PME_STS
 #define EC_GPE_LID 0x6B // PME_STS
 #define EC_GPE_SCI 0x6E // ESPI_SCI
@@ -25,66 +23,4 @@ Scope (\_SB) {
 
 Scope (_GPE) {
 	#include <ec/clevo/it5570/acpi/gpe.asl>
-}
-
-External (\_SB.PCI0.RP11.PXSX.VDID, FieldUnitObj)
-External (\_SB.PCI0.PMC.IPCS,MEthodObj)
-
-/* Handle Bluetooth RFkill */
-Scope (\_SB.PCI0.XHCI.RHUB.HS10)
-{
-	PowerResource (BTPR, 0x00, 0x0000)
-	{
-		Method (_STA, 0, NotSerialized)
-		{
-			If ((\_SB.PCI0.GTXS(GPP_A13) == One))
-			{
-				Return (One)
-			}
-			Else
-			{
-				Return (Zero)
-			}
-		}
-
-		Method (_ON, 0, Serialized)
-		{
-			\_SB.PCI0.STXS (GPP_A13)
-		}
-
-		Method (_OFF, 0, Serialized)
-		{
-			\_SB.PCI0.CTXS (GPP_A13)
-		}
-	}
-	Name (_S0W, 0x02)
-
-	Method(GPR, 0, NotSerialized)
-	{
-		If(CondRefOf(\_SB.PCI0.CNVW))
-		{
-			Return (Package (0x01)
-			{
-				BTPR
-			})
-		}
-		If(CondRefOf(\_SB.PCI0.RP11.PXSX))
-		{
-			Return (Package (0x01)
-			{
-				BTPR
-			})
-		}
-		Return (Package (0x00){})
-	}
-
-	Method (_PR0, 0, NotSerialized)
-	{
-		Return (GPR())
-	}
-
-	Method (_PR3, 0, NotSerialized)
-	{
-		Return (GPR())
-	}
 }


### PR DESCRIPTION
Remove bluetooth PowerResource from the mainboard ACPI code.
It was added as an attempt to get S0ix working, but is no longer needed.

Fixes bluetooth operation on Windows 10 with AX200 (PCIe) and AX201 (CNVi) cards.
S0ix is still entered according to `/sys/kernel/debug/pmc_core/package_cstate_show`.

Partially addresses issue https://gitlab.com/novacustom/dasharo-compatibility/-/issues/12

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>