### PR TITLE
XBus / SMP link configuration

### DIFF
--- a/src/include/cpu/power/istep_8.h
+++ b/src/include/cpu/power/istep_8.h
@@ -13,9 +13,4 @@ void istep_8_9(uint8_t chips);
 void istep_8_10(uint8_t chips);
 void istep_8_11(uint8_t chips);
 
-/* These functions access SCOM of the second CPU using SBE IO, thus they can be
- * used only in isteps that come after 8.4 */
-void put_scom(uint8_t chip, uint64_t addr, uint64_t data);
-uint64_t get_scom(uint8_t chip, uint64_t addr);
-
 #endif /* CPU_PPC64_ISTEP8_H */

--- a/src/include/cpu/power/istep_9.h
+++ b/src/include/cpu/power/istep_9.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef CPU_PPC64_ISTEP9_H
+#define CPU_PPC64_ISTEP9_H
+
+#include <stdint.h>
+
+void istep_9_2(uint8_t chips);
+
+#endif /* CPU_PPC64_ISTEP8_H */

--- a/src/include/cpu/power/istep_9.h
+++ b/src/include/cpu/power/istep_9.h
@@ -6,5 +6,6 @@
 #include <stdint.h>
 
 void istep_9_2(uint8_t chips);
+void istep_9_4(uint8_t chips);
 
 #endif /* CPU_PPC64_ISTEP8_H */

--- a/src/include/cpu/power/istep_9.h
+++ b/src/include/cpu/power/istep_9.h
@@ -7,5 +7,6 @@
 
 void istep_9_2(uint8_t chips);
 void istep_9_4(uint8_t chips);
+void istep_9_6(uint8_t chips);
 
 #endif /* CPU_PPC64_ISTEP8_H */

--- a/src/include/cpu/power/istep_9.h
+++ b/src/include/cpu/power/istep_9.h
@@ -8,5 +8,6 @@
 void istep_9_2(uint8_t chips);
 void istep_9_4(uint8_t chips);
 void istep_9_6(uint8_t chips);
+void istep_9_7(uint8_t chips);
 
 #endif /* CPU_PPC64_ISTEP8_H */

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -16,6 +16,7 @@ romstage-y += istep_8_4.c
 romstage-y += istep_8_9.c
 romstage-y += istep_8_10.c
 romstage-y += istep_8_11.c
+romstage-y += istep_9_2.c
 romstage-y += istep_10_10.c
 romstage-y += istep_10_12.c
 romstage-y += istep_10_13.c

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -38,6 +38,7 @@ romstage-y += mcbist.c
 romstage-y += timer.c
 romstage-y += fsi.c
 romstage-y += sbeio.c
+romstage-y += xbus.c
 ramstage-y += chip.c
 ramstage-y += homer.c
 ramstage-y += rom_media.c

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -19,6 +19,7 @@ romstage-y += istep_8_11.c
 romstage-y += istep_9_2.c
 romstage-y += istep_9_4.c
 romstage-y += istep_9_6.c
+romstage-y += istep_9_7.c
 romstage-y += istep_10_10.c
 romstage-y += istep_10_12.c
 romstage-y += istep_10_13.c

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -17,6 +17,7 @@ romstage-y += istep_8_9.c
 romstage-y += istep_8_10.c
 romstage-y += istep_8_11.c
 romstage-y += istep_9_2.c
+romstage-y += istep_9_4.c
 romstage-y += istep_10_10.c
 romstage-y += istep_10_12.c
 romstage-y += istep_10_13.c

--- a/src/soc/ibm/power9/Makefile.inc
+++ b/src/soc/ibm/power9/Makefile.inc
@@ -18,6 +18,7 @@ romstage-y += istep_8_10.c
 romstage-y += istep_8_11.c
 romstage-y += istep_9_2.c
 romstage-y += istep_9_4.c
+romstage-y += istep_9_6.c
 romstage-y += istep_10_10.c
 romstage-y += istep_10_12.c
 romstage-y += istep_10_13.c

--- a/src/soc/ibm/power9/istep_8_10.c
+++ b/src/soc/ibm/power9/istep_8_10.c
@@ -6,23 +6,7 @@
 #include <cpu/power/scom.h>
 #include <delay.h>
 
-static inline void and_scom(uint8_t chip, uint64_t addr, uint64_t mask)
-{
-	put_scom(chip, addr, get_scom(chip, addr) & mask);
-}
-
-static inline void or_scom(uint8_t chip, uint64_t addr, uint64_t mask)
-{
-	put_scom(chip, addr, get_scom(chip, addr) | mask);
-}
-
-static inline void and_or_scom(uint8_t chip, uint64_t addr, uint64_t and, uint64_t or)
-{
-	uint64_t data = get_scom(chip, addr);
-	data &= and;
-	data |= or;
-	put_scom(chip, addr, data);
-}
+#include "xbus.h"
 
 static void xbus_scom(uint8_t chip, uint8_t group)
 {
@@ -37,7 +21,7 @@ static void xbus_scom(uint8_t chip, uint8_t group)
 	 * use the offset.  Some other writes are group-specific and don't need
 	 * it either.
 	 */
-	const uint64_t offset = group * 0x2000000000;
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
 
 	int i;
 
@@ -332,7 +316,7 @@ static void set_msb_swap(uint8_t chip, int group)
 		EDIP_TX_MSBSWAP = 58,
 	};
 
-	const uint64_t offset = group * 0x2000000000;
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
 
 	/* ATTR_EI_BUS_TX_MSBSWAP seems to be 0x80 which is GROUP_0_SWAP */
 	if (group == 0)
@@ -357,7 +341,7 @@ static void xbus_scominit(int group)
 		EDIP_TX_IORESET = 0x800C9C0006010C3F,
 	};
 
-	const uint64_t offset = group * 0x2000000000;
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
 
 	/* Assert IO reset to power-up bus endpoint logic */
 	or_scom(0, EDIP_RX_IORESET + offset, PPC_BIT(52));

--- a/src/soc/ibm/power9/istep_8_11.c
+++ b/src/soc/ibm/power9/istep_8_11.c
@@ -5,6 +5,8 @@
 #include <console/console.h>
 #include <cpu/power/scom.h>
 
+#include "xbus.h"
+
 static void xbus_enable_ridi(uint8_t chip)
 {
 	enum {

--- a/src/soc/ibm/power9/istep_8_9.c
+++ b/src/soc/ibm/power9/istep_8_9.c
@@ -6,63 +6,15 @@
 #include <cpu/power/powerbus.h>
 #include <cpu/power/scom.h>
 
-#include "sbeio.h"
-#include "scratch.h"
-
 #include "fsi.h"
+#include "scratch.h"
+#include "xbus.h"
 
 /*
  * This code omits initialization of OBus which isn't present. It also assumes
  * there is only one XBus (X1). Both of these statements are true for Nimbus
  * Sforza.
  */
-
-/* Updates address that targets XBus chiplet to use specified XBus link number.
- * Does nothing to non-XBus addresses. */
-static uint64_t xbus_addr(uint8_t xbus, uint64_t addr)
-{
-	enum {
-		XBUS_COUNT = 0x3,		// number of XBus links
-		XB_IOX_0_RING_ID = 0x3,		// IOX_0
-		XB_PBIOX_0_RING_ID = 0x6,	// PBIOX_0
-	};
-
-	uint8_t ring = (addr >> 10) & 0xF;
-	uint8_t chiplet = (addr >> 24) & 0x3F;
-
-	if (chiplet != XB_CHIPLET_ID)
-		return addr;
-
-	if (ring >= XB_IOX_0_RING_ID && ring < XB_IOX_0_RING_ID + XBUS_COUNT)
-		ring = XB_IOX_0_RING_ID + xbus;
-	else if (ring >= XB_PBIOX_0_RING_ID && ring < XB_PBIOX_0_RING_ID + XBUS_COUNT)
-		ring = XB_PBIOX_0_RING_ID + xbus;
-
-	addr &= ~PPC_BITMASK(50, 53);
-	addr |= PPC_PLACE(ring, 50, 4);
-
-	return addr;
-}
-
-void put_scom(uint8_t chip, uint64_t addr, uint64_t data)
-{
-	addr = xbus_addr(/*xbus=*/1, addr);
-
-	if (chip == 0)
-		write_scom(addr, data);
-	else
-		write_sbe_scom(chip, addr, data);
-}
-
-uint64_t get_scom(uint8_t chip, uint64_t addr)
-{
-	addr = xbus_addr(/*xbus=*/1, addr);
-
-	if (chip == 0)
-		return read_scom(addr);
-	else
-		return read_sbe_scom(chip, addr);
-}
 
 static void p9_fbc_no_hp_scom(uint8_t chip)
 {

--- a/src/soc/ibm/power9/istep_9_2.c
+++ b/src/soc/ibm/power9/istep_9_2.c
@@ -1,0 +1,311 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/power/istep_9.h>
+
+#include <console/console.h>
+#include <cpu/power/scom.h>
+#include <delay.h>
+#include <timer.h>
+
+#include "fsi.h"
+#include "xbus.h"
+
+struct edip_data_t {
+	uint32_t en_margin_pu;
+	uint32_t en_margin_pd;
+	uint32_t en_main;
+	uint32_t sel_pre;
+};
+
+static void compute_margin_data(uint32_t margin, struct edip_data_t *d)
+{
+	/* ATTR_IO_XBUS_TX_FFE_PRECURSOR = 6 (default, talos.xml) */
+	const uint8_t ffe_pre_coef = 6;
+
+	/* Need to convert the 8R value to a 4R equivalent */
+
+	const uint32_t val = margin >> 1;
+	const uint32_t en_pre = 18;
+
+	uint32_t val_4r = val - en_pre;
+
+	d->en_margin_pu = 32;
+	d->en_margin_pd = 32;
+	d->en_main = 0;
+	d->sel_pre = 0;
+
+	if (val_4r < 64) {
+		if (val_4r % 4 != 0) {
+			d->en_main = 2;
+			val_4r -= d->en_main;
+		}
+		d->en_margin_pd = val_4r / 2;
+		d->en_margin_pu = val_4r - d->en_margin_pd;
+	}
+
+	d->en_main += val_4r - d->en_margin_pu - d->en_margin_pd;
+	d->en_main = MIN(d->en_main, 50);
+	d->sel_pre = (val * ffe_pre_coef) / 128;
+	d->sel_pre = MIN(d->sel_pre, en_pre);
+}
+
+/* Converts a 4R decimal value to a 1R thermometer code */
+static uint32_t convert_4r(uint32_t val_4r)
+{
+	/*
+	 * 1. Add 2 for averaging since we will truncate the last 2 bits.
+	 * 2. Divide by 4 to bring back to a 1r value.
+	 * 3. Convert the decimal number to number of bits set by shifting a 0x1
+	 *    over by the amount and subtracting 1.
+	 */
+	return (0x1 << ((val_4r + 2) / 4)) - 1;
+}
+
+static uint32_t convert_4r_with_2r(uint32_t val_4r, uint8_t width)
+{
+	/* Add 1 for rounding, then shift the 4r bit off. We now have a 2r equivalent */
+	const uint32_t val_2r = (val_4r + 1) >> 1;
+
+	/* If the LSB of the 2r equivalent is on, then we need to set the 2r bit (MSB) */
+	const uint32_t on_2r = val_2r & 0x1;
+
+	/* Shift the 2r equivalent to a 1r value and convert to a thermometer code */
+	const uint32_t val_1r = (1 << (val_2r >> 0x1)) - 1;
+
+	/* Combine 1r equivalent thermometer code + the 2r MSB value */
+	return (on_2r << (width - 1)) | val_1r;
+}
+
+static void config_run_bus_group_mode(uint8_t chip, int group)
+{
+	enum {
+		P9A_XBUS_TX_IMPCAL_PVAL_PB = 0x800F140006010C3F,
+		P9A_XBUS_TX_IMPCAL_NVAL_PB = 0x800F0C0006010C3F,
+	};
+
+	/* ATTR_IO_XBUS_TX_MARGIN_RATIO = 0 (default) */
+	const uint8_t margin_ratio = 0;
+
+	const uint8_t PRE_WIDTH     = 5;
+	/*             4R Total     = (1R * 4) + (2R * 2); */
+	const uint32_t PRE_4R_TOTAL = ( 4 * 4) + ( 1 * 2);
+
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
+
+	/* Same registers are read for both groups */
+	uint32_t pval = (get_scom(chip, P9A_XBUS_TX_IMPCAL_PVAL_PB) >> 7) & 0x1FF;
+	uint32_t nval = (get_scom(chip, P9A_XBUS_TX_IMPCAL_NVAL_PB) >> 7) & 0x1FF;
+
+	uint32_t sel_margin_pu;
+	uint32_t sel_margin_pd;
+
+	struct edip_data_t p;
+	struct edip_data_t n;
+
+	uint64_t val;
+
+	compute_margin_data(pval, &p);
+	compute_margin_data(nval, &n);
+
+	sel_margin_pu = (pval * margin_ratio) / 256;
+	sel_margin_pu = MIN(sel_margin_pu, MIN(p.en_margin_pu, n.en_margin_pu));
+
+	sel_margin_pd = (nval * margin_ratio) / 256;
+	sel_margin_pd = MIN(sel_margin_pd,
+			    MIN(p.en_margin_pd, MIN(n.en_margin_pd, sel_margin_pu)));
+
+	val = get_scom(chip, 0x800D340006010C3F + offset);
+
+	/* EDIP_TX_PSEG_PRE_EN (pre bank pseg enable) */
+	PPC_INSERT(val, convert_4r_with_2r(PRE_4R_TOTAL, PRE_WIDTH), 51, 5);
+	/* EDIP_TX_PSEG_PRE_SEL (pre bank pseg mode selection) */
+	PPC_INSERT(val, convert_4r_with_2r(p.sel_pre, PRE_WIDTH), 56, 5);
+
+	put_scom(chip, 0x800D340006010C3F + offset, val);
+	val = get_scom(chip, 0x800D3C0006010C3F + offset);
+
+	/* EDIP_TX_NSEG_PRE_EN (pre bank nseg enable) */
+	PPC_INSERT(val, convert_4r_with_2r(PRE_4R_TOTAL, PRE_WIDTH), 51, 5);
+	/* EDIP_TX_NSEG_PRE_SEL (pre bank nseg mode selection) */
+	PPC_INSERT(val, convert_4r_with_2r(n.sel_pre, PRE_WIDTH), 56, 5);
+
+	put_scom(chip, 0x800D3C0006010C3F + offset, val);
+	val = get_scom(chip, 0x800D440006010C3F + offset);
+
+	/* EDIP_TX_PSEG_MARGINPD_EN (margin pull-down bank pseg enable) */
+	PPC_INSERT(val, convert_4r(p.en_margin_pd), 56, 8);
+	/* EDIP_TX_PSEG_MARGINPU_EN (margin pull-up bank pseg enable) */
+	PPC_INSERT(val, convert_4r(p.en_margin_pu), 48, 8);
+
+	put_scom(chip, 0x800D440006010C3F + offset, val);
+	val = get_scom(chip, 0x800D4C0006010C3F + offset);
+
+	/* EDIP_TX_NSEG_MARGINPD_EN (margin pull-down bank nseg enable) */
+	PPC_INSERT(val, convert_4r(n.en_margin_pd), 56, 8);
+	/* EDIP_TX_NSEG_MARGINPU_EN (margin pull-up bank nseg enable) */
+	PPC_INSERT(val, convert_4r(n.en_margin_pu), 48, 8);
+
+	put_scom(chip, 0x800D4C0006010C3F + offset, val);
+	val = get_scom(chip, 0x800D540006010C3F + offset);
+
+	/* EDIP_TX_MARGINPD_SEL (margin pull-down bank mode selection) */
+	PPC_INSERT(val, convert_4r(sel_margin_pd), 56, 8);
+	/* EDIP_TX_MARGINPU_SEL (margin pull-up bank mode selection) */
+	PPC_INSERT(val, convert_4r(sel_margin_pu), 48, 8);
+
+	put_scom(chip, 0x800D540006010C3F + offset, val);
+
+	/* EDIP_TX_PSEG_MAIN_EN (main bank pseg enable) */
+	val = get_scom(chip, 0x800D5C0006010C3F + offset);
+	PPC_INSERT(val, convert_4r_with_2r(p.en_main, 13), 51, 13);
+	put_scom(chip, 0x800D5C0006010C3F + offset, val);
+
+	/* EDIP_TX_NSEG_MAIN_EN (main bank nseg enable) */
+	val = get_scom(chip, 0x800D640006010C3F + offset);
+	PPC_INSERT(val, convert_4r_with_2r(n.en_main, 13), 51, 13);
+	put_scom(chip, 0x800D640006010C3F + offset, val);
+}
+
+static void config_run_bus_mode(uint8_t chip)
+{
+	enum {
+		P9A_XBUS_TX_IMPCAL_PB = 0x800F040006010C3F,
+		EDIP_TX_ZCAL_DONE = 50,
+		EDIP_TX_ZCAL_ERROR = 51,
+	};
+
+	long time;
+
+	/* Set EDIP_TX_ZCAL_REQ to start Tx Impedance Calibration */
+	or_scom(chip, P9A_XBUS_TX_IMPCAL_PB, PPC_BIT(49));
+	udelay(20 * 1000); // 20ms
+
+	time = wait_us(200 * 10, get_scom(chip, P9A_XBUS_TX_IMPCAL_PB) &
+		       (PPC_BIT(EDIP_TX_ZCAL_DONE) | PPC_BIT(EDIP_TX_ZCAL_ERROR)));
+	if (!time)
+		die("Timed out waiting for I/O EDI+ Xbus Tx Z Calibration\n");
+
+	if (get_scom(chip, P9A_XBUS_TX_IMPCAL_PB) & PPC_BIT(EDIP_TX_ZCAL_ERROR))
+		die("I/O EDI+ Xbus Tx Z Calibration failed\n");
+
+	config_run_bus_group_mode(chip, /*group=*/0);
+	config_run_bus_group_mode(chip, /*group=*/1);
+}
+
+static void rx_dc_calibration_start(uint8_t chip, int group)
+{
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
+
+	/* Must set lane invalid bit to 0 to run rx dccal, this enables us to
+	 * run dccal on the specified lane. These bits are normally set by
+	 * wiretest although we are not running that now. */
+	for (int i = 0; i < XBUS_LANE_COUNT; i++) {
+		uint64_t lane_offset = PPC_PLACE(i, 27, 5);
+		/* EDIP_RX_LANE_INVALID */
+		and_scom(chip, 0x8002400006010C3F | offset | lane_offset, ~PPC_BIT(50));
+	}
+
+	/* Start Cleanup Pll */
+
+	/*
+	 * EDIP_RX_CTL_CNTL4_E_PG
+	 *  50 - EDIP_RX_WT_PLL_REFCLKSEL (0 - io clock, 1 - bist)
+	 *  51 - EDIP_RX_PLL_REFCLKSEL_SCOM_EN (0 - pll controls selects refclk,
+	 *                                      1 - and gcr register does it)
+	 */
+	or_scom(chip, 0x8009F80006010C3F + offset, PPC_BIT(50) | PPC_BIT(51));
+	udelay(150);
+
+	/*
+	 * EDIP_RX_CTL_CNTL4_E_PG
+	 *  48 - EDIP_RX_WT_CU_PLL_PGOOD (0 - places rx pll in reset,
+	 *                                1 - sets pgood on rx pll for locking)
+	 */
+	or_scom(chip, 0x8009F80006010C3F + offset, PPC_BIT(48));
+	udelay(5);
+
+	/*
+	 * EDIP_RX_DC_CALIBRATE_DONE
+	 * (when this bit is read as a 1, the dc calibration steps have been completed)
+	 */
+	and_scom(chip, 0x800A380006010C3F + offset, ~PPC_BIT(53));
+
+	/*
+	 * EDIP_RX_START_DC_CALIBRATE
+	 * (when this register is written to a 1 the training state machine will run the dc
+	 *  calibrate substeps defined in eye optimizations)
+	 */
+	or_scom(chip, 0x8009F00006010C3F + offset, PPC_BIT(53));
+}
+
+static void rx_dc_calibration_poll(uint8_t chip, int group)
+{
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
+
+	long time;
+
+	udelay(100 * 1000); // 100ms
+
+	/*
+	 * EDIP_RX_DC_CALIBRATE_DONE
+	 * (when this bit is read as a 1, the dc calibration steps have been completed)
+	 */
+	time = wait_ms(200 * 10, get_scom(chip, 0x800A380006010C3F + offset) & PPC_BIT(53));
+	if (!time)
+		die("Timed out waiting for Rx Dc Calibration\n");
+
+	/*
+	 * EDIP_RX_START_DC_CALIBRATE
+	 * (when this register is written to a 1 the training state machine will run the dc
+	 *  calibrate substeps defined in eye optimizations)
+	 */
+	and_scom(chip, 0x8009F00006010C3F + offset, ~PPC_BIT(53));
+
+	/*
+	 * EDIP_RX_CTL_CNTL4_E_PG
+	 *  48 - EDIP_RX_WT_CU_PLL_PGOOD (0 - places rx pll in reset,
+	 *                                1 - sets pgood on rx pll for locking)
+	 *  50 - EDIP_RX_WT_PLL_REFCLKSEL (0 - io clock, 1 - bist)
+	 *  51 - EDIP_RX_PLL_REFCLKSEL_SCOM_EN (0 - pll controls selects refclk,
+	 *                                      1 - and gcr register does it)
+	 */
+	and_scom(chip, 0x8009F80006010C3F + offset, ~(PPC_BIT(48) | PPC_BIT(50) | PPC_BIT(51)));
+	udelay(111);
+
+	/* Restore the invalid bits, Wiretest will modify these as training is run */
+	for (int i = 0; i < XBUS_LANE_COUNT; i++) {
+		uint64_t lane_offset = PPC_PLACE(i, 27, 5);
+		/* EDIP_RX_LANE_INVALID */
+		or_scom(chip, 0x8002400006010C3F | offset | lane_offset, PPC_BIT(50));
+	}
+}
+
+static void config_bus_mode(void)
+{
+	/* Initiate Dc calibration in parallel */
+	rx_dc_calibration_start(/*chip=*/0, /*group=*/0);
+	rx_dc_calibration_start(/*chip=*/1, /*group=*/0);
+	rx_dc_calibration_start(/*chip=*/0, /*group=*/1);
+	rx_dc_calibration_start(/*chip=*/1, /*group=*/1);
+
+	/* Then wait for each combination of chip and group */
+	rx_dc_calibration_poll(/*chip=*/0, /*group=*/0);
+	rx_dc_calibration_poll(/*chip=*/1, /*group=*/0);
+	rx_dc_calibration_poll(/*chip=*/0, /*group=*/1);
+	rx_dc_calibration_poll(/*chip=*/1, /*group=*/1);
+}
+
+void istep_9_2(uint8_t chips)
+{
+	printk(BIOS_EMERG, "starting istep 9.2\n");
+	report_istep(9,2);
+
+	if (chips != 0x01) {
+		config_run_bus_mode(/*chip=*/0);
+		config_run_bus_mode(/*chip=*/1);
+
+		config_bus_mode();
+	}
+
+	printk(BIOS_EMERG, "ending istep 9.2\n");
+}

--- a/src/soc/ibm/power9/istep_9_4.c
+++ b/src/soc/ibm/power9/istep_9_4.c
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/power/istep_9.h>
+
+#include <console/console.h>
+#include <cpu/power/scom.h>
+#include <timer.h>
+
+#include "xbus.h"
+
+static void tx_serializer_sync_power_on(uint8_t master_chip, uint8_t slave_chip, int group)
+{
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
+
+	/*
+	 * EDIP_TX_CLK_UNLOAD_CLK_DISABLE
+	 * (set to 0 to clock off sync logic on the clock slice and save power;
+	 *  it should not be necessary to use the sync logic on the clock slice
+	 *  since it has no fifo but control is available just in case)
+	 */
+	and_scom(master_chip, 0x800C1C0006010C3F + offset, ~PPC_BIT(50));
+	and_scom(slave_chip, 0x800C1C0006010C3F + offset, ~PPC_BIT(50));
+
+	/*
+	 * EDIP_TX_CLK_RUN_COUNT
+	 * (set to 1 to enable the tx clock slice serializer; this should be
+	 *  enabled at all times but control is available just in case)
+	 */
+	and_scom(master_chip, 0x800C1C0006010C3F + offset, ~PPC_BIT(51));
+	and_scom(slave_chip, 0x800C1C0006010C3F + offset, ~PPC_BIT(51));
+
+	/* EDIP_TX_CLK_RUN_COUNT (see above) */
+	or_scom(master_chip, 0x800C1C0006010C3F + offset, PPC_BIT(51));
+	or_scom(slave_chip, 0x800C1C0006010C3F + offset, PPC_BIT(51));
+
+	/* EDIP_TX_CLK_UNLOAD_CLK_DISABLE (see above) */
+	or_scom(master_chip, 0x800C1C0006010C3F + offset, PPC_BIT(50));
+	or_scom(slave_chip, 0x800C1C0006010C3F + offset, PPC_BIT(50));
+
+	for (int i = 0; i < XBUS_LANE_COUNT; ++i) {
+		uint64_t lane_offset = PPC_PLACE(i, 27, 5);
+		/*
+		 * EDIP_TX_UNLOAD_CLK_DISABLE
+		 * (set to 0 to enable sync of tx custom serializer via tx_fifo_init register,
+		 *  set to 1 to clock off sync logic and save power)
+		 */
+		and_scom(master_chip, 0x80040C0006010C3F | offset | lane_offset, ~PPC_BIT(56));
+		and_scom(slave_chip, 0x80040C0006010C3F | offset | lane_offset, ~PPC_BIT(56));
+	}
+}
+
+static void xbus_linktrain(uint8_t master_chip, uint8_t slave_chip, int group)
+{
+	enum {
+		/* I/O EDI+ Training Substeps */
+		NONE       = 0x00000000,
+		WIRETEST   = 0x00000001,
+		DESKEW     = 0x00000002,
+		EYEOPT     = 0x00000004,
+		REPAIR     = 0x00000008,
+		FUNCTIONAL = 0x00000010,
+		WDERF      = 0x0000001F, // all of the above
+	};
+
+	const uint64_t offset = group * XBUS_LINK_GROUP_OFFSET;
+
+	uint64_t tmp;
+
+	/* Hostboot collects bad lane information here, we don't */
+
+	/*
+	 * Clock Serializer Init
+	 * Isn't strictly necessary but does line up the clock serializer
+	 * counter with the data slices.
+	 */
+	tx_serializer_sync_power_on(master_chip, slave_chip, group);
+
+	/* Start Slave/Master Target Link Training */
+
+	/*
+	 * EDIP_RX_START_WDERF_ALIAS (alias for rx_start_* bits)
+	 * Slave training must start first.
+	 */
+	and_or_scom(slave_chip, 0x8009F00006010C3F + offset,
+		    ~PPC_BITMASK(48, 52), PPC_PLACE(WDERF, 48, 5));
+	and_or_scom(master_chip, 0x8009F00006010C3F + offset,
+		    ~PPC_BITMASK(48, 52), PPC_PLACE(WDERF, 48, 5));
+
+	/*
+	 * 48-52  EDIP_RX_WDERF_DONE_ALIAS (alias for rx_*_done bits)
+	 * 56-60  EDIP_RX_WDERF_FAILED_ALIAS (alias for rx_*_failed bits)
+	 */
+	wait_ms(100 * 1,
+		(tmp = get_scom(master_chip, 0x800A380006010C3F + offset),
+		 (((tmp >> 11) & 0x1F) == WDERF || ((tmp >> 3) & 0x1F) != 0)));
+	if (((tmp >> 3) & 0x1F) != 0)
+		die("I/O EDI+ Xbus link training failed.\n");
+	if (((tmp >> 11) & 0x1F) != WDERF)
+		die("I/O EDI+ Xbus link training timeout.\n");
+
+}
+
+void istep_9_4(uint8_t chips)
+{
+	printk(BIOS_EMERG, "starting istep 9.4\n");
+	report_istep(9,4);
+
+	if (chips != 0x01) {
+		xbus_linktrain(/*master_chip=*/0, /*slave_chip=*/1, /*group=*/0);
+		xbus_linktrain(/*master_chip=*/0, /*slave_chip=*/1, /*group=*/1);
+	}
+
+	printk(BIOS_EMERG, "ending istep 9.4\n");
+}

--- a/src/soc/ibm/power9/istep_9_6.c
+++ b/src/soc/ibm/power9/istep_9_6.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/power/istep_9.h>
+
+#include <console/console.h>
+#include <cpu/power/scom.h>
+
+#include "xbus.h"
+
+static void smp_link_layer(uint8_t chip)
+{
+	enum {
+		/* dl_control_addr */
+		XBUS_LL1_IOEL_CONTROL = 0x0000000006011C0B,
+
+		XBUS_LL0_IOEL_CONTROL_LINK0_STARTUP = 1,
+		XBUS_LL0_IOEL_CONTROL_LINK1_STARTUP = 33,
+	};
+
+	/* Hostboot uses PUTSCOMMASK operation of SBE IO. Assuming that it's
+	 * equivalent to a RMW sequence. */
+	or_scom(chip, XBUS_LL1_IOEL_CONTROL,
+		PPC_BIT(XBUS_LL0_IOEL_CONTROL_LINK0_STARTUP) |
+		PPC_BIT(XBUS_LL0_IOEL_CONTROL_LINK1_STARTUP));
+}
+
+void istep_9_6(uint8_t chips)
+{
+	printk(BIOS_EMERG, "starting istep 9.6\n");
+	report_istep(9,6);
+
+	if (chips != 0x01) {
+		smp_link_layer(/*chip=*/0);
+		smp_link_layer(/*chip=*/1);
+	}
+
+	printk(BIOS_EMERG, "ending istep 9.6\n");
+}

--- a/src/soc/ibm/power9/istep_9_7.c
+++ b/src/soc/ibm/power9/istep_9_7.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/power/istep_9.h>
+
+#include <console/console.h>
+#include <cpu/power/scom.h>
+#include <delay.h>
+#include <stdbool.h>
+
+#include "xbus.h"
+
+static void p9_fab_iovalid_link_validate(uint8_t chip)
+{
+	enum {
+		XBUS_LL1_IOEL_FIR_REG = 0x06011C00,
+		DL_FIR_LINK0_TRAINED_BIT = 0,
+		DL_FIR_LINK1_TRAINED_BIT = 1,
+	};
+
+	int i;
+
+	for (i = 0; i < 100; ++i) {
+		/* Only OBus seems to be retrained, so this XBus-only code is
+		 * much simpler compared to corresponding code in Hostboot */
+
+		uint64_t dl_fir_reg = get_scom(chip, XBUS_LL1_IOEL_FIR_REG);
+
+		bool dl_trained = (dl_fir_reg & PPC_BIT(DL_FIR_LINK0_TRAINED_BIT))
+			       && (dl_fir_reg & PPC_BIT(DL_FIR_LINK1_TRAINED_BIT));
+		if (dl_trained)
+			break;
+
+		udelay(1 * 1000); // 1ms
+	}
+
+	if (i == 100)
+		die("XBus link DL training failed\n");
+}
+
+static void p9_fab_iovalid(uint8_t chip)
+{
+	enum {
+		PERV_XB_CPLT_CONF1_OR = 0x06000019,
+		PERV_CPLT_CONF1_IOVALID_6D = 6,
+
+		PU_PB_CENT_SM0_PB_CENT_FIR_REG = 0x05011C00,
+		PU_PB_CENT_SM0_PB_CENT_FIR_MASK_REG_SPARE_13 = 13,
+
+		PU_PB_CENT_SM1_EXTFIR_ACTION0_REG = 0x05011C34,
+		PU_PB_CENT_SM1_EXTFIR_ACTION1_REG = 0x05011C35,
+
+		PU_PB_CENT_SM1_EXTFIR_MASK_REG_AND = 0x05011C32,
+	};
+
+	uint64_t fbc_cent_fir_data;
+
+	/* Add delay for DD1.1+ procedure to compensate for lack of lane lock
+	 * polls */
+	udelay(100 * 1000); // 100ms
+
+	p9_fab_iovalid_link_validate(chip);
+
+	/* Clear RAS FIR mask for link if not already set up by SBE */
+	fbc_cent_fir_data = get_scom(chip, PU_PB_CENT_SM0_PB_CENT_FIR_REG);
+	if (!(fbc_cent_fir_data & PPC_BIT(PU_PB_CENT_SM0_PB_CENT_FIR_MASK_REG_SPARE_13))) {
+		and_scom(chip, PU_PB_CENT_SM1_EXTFIR_ACTION0_REG,
+			 ~PPC_BIT(PERV_CPLT_CONF1_IOVALID_6D));
+		and_scom(chip, PU_PB_CENT_SM1_EXTFIR_ACTION1_REG,
+			 ~PPC_BIT(PERV_CPLT_CONF1_IOVALID_6D));
+		put_scom(chip, PU_PB_CENT_SM1_EXTFIR_MASK_REG_AND,
+			 ~PPC_BIT(PERV_CPLT_CONF1_IOVALID_6D));
+	}
+
+	/*
+	 * Use AND/OR mask registers to atomically update link specific fields
+	 * in iovalid control register.
+	 */
+	put_scom(chip, PERV_XB_CPLT_CONF1_OR,
+		 PPC_BIT(PERV_CPLT_CONF1_IOVALID_6D) |
+		 PPC_BIT(PERV_CPLT_CONF1_IOVALID_6D + 1));
+}
+
+void istep_9_7(uint8_t chips)
+{
+	printk(BIOS_EMERG, "starting istep 9.7\n");
+	report_istep(9,7);
+
+	if (chips != 0x01) {
+		p9_fab_iovalid(/*chip=*/0);
+		p9_fab_iovalid(/*chip=*/1);
+	}
+
+	printk(BIOS_EMERG, "ending istep 9.7\n");
+}

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -3,6 +3,7 @@
 #include <console/console.h>
 #include <cpu/power/vpd.h>
 #include <cpu/power/istep_8.h>
+#include <cpu/power/istep_9.h>
 #include <cpu/power/istep_10.h>
 #include <cpu/power/istep_13.h>
 #include <cpu/power/istep_14.h>
@@ -371,6 +372,8 @@ void main(void)
 	istep_8_9(chips);
 	istep_8_10(chips);
 	istep_8_11(chips);
+
+	istep_9_2(chips);
 
 	istep_10_10(&phb_active_mask, iovalid_enable);
 	istep_10_12();

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -375,6 +375,7 @@ void main(void)
 
 	istep_9_2(chips);
 	istep_9_4(chips);
+	istep_9_6(chips);
 
 	istep_10_10(&phb_active_mask, iovalid_enable);
 	istep_10_12();

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -374,6 +374,7 @@ void main(void)
 	istep_8_11(chips);
 
 	istep_9_2(chips);
+	istep_9_4(chips);
 
 	istep_10_10(&phb_active_mask, iovalid_enable);
 	istep_10_12();

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -376,6 +376,7 @@ void main(void)
 	istep_9_2(chips);
 	istep_9_4(chips);
 	istep_9_6(chips);
+	istep_9_7(chips);
 
 	istep_10_10(&phb_active_mask, iovalid_enable);
 	istep_10_12();

--- a/src/soc/ibm/power9/xbus.c
+++ b/src/soc/ibm/power9/xbus.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include "xbus.h"
+
+#include <cpu/power/scom.h>
+#include <stdint.h>
+
+#include "sbeio.h"
+
+/* Updates address that targets XBus chiplet to use specified XBus link number.
+ * Does nothing to non-XBus addresses. */
+static uint64_t xbus_addr(uint8_t xbus, uint64_t addr)
+{
+	enum {
+		XBUS_COUNT = 0x3,		// number of XBus links
+		XB_IOX_0_RING_ID = 0x3,		// IOX_0
+		XB_PBIOX_0_RING_ID = 0x6,	// PBIOX_0
+	};
+
+	uint8_t ring = (addr >> 10) & 0xF;
+	uint8_t chiplet = (addr >> 24) & 0x3F;
+
+	if (chiplet != XB_CHIPLET_ID)
+		return addr;
+
+	if (ring >= XB_IOX_0_RING_ID && ring < XB_IOX_0_RING_ID + XBUS_COUNT)
+		ring = XB_IOX_0_RING_ID + xbus;
+	else if (ring >= XB_PBIOX_0_RING_ID && ring < XB_PBIOX_0_RING_ID + XBUS_COUNT)
+		ring = XB_PBIOX_0_RING_ID + xbus;
+
+	addr &= ~PPC_BITMASK(50, 53);
+	addr |= PPC_PLACE(ring, 50, 4);
+
+	return addr;
+}
+
+void put_scom(uint8_t chip, uint64_t addr, uint64_t data)
+{
+	addr = xbus_addr(/*xbus=*/1, addr);
+
+	if (chip == 0)
+		write_scom(addr, data);
+	else
+		write_sbe_scom(chip, addr, data);
+}
+
+uint64_t get_scom(uint8_t chip, uint64_t addr)
+{
+	addr = xbus_addr(/*xbus=*/1, addr);
+
+	if (chip == 0)
+		return read_scom(addr);
+	else
+		return read_sbe_scom(chip, addr);
+}

--- a/src/soc/ibm/power9/xbus.h
+++ b/src/soc/ibm/power9/xbus.h
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef __SOC_IBM_POWER9_XBUS_H
+#define __SOC_IBM_POWER9_XBUS_H
+
+#include <stdint.h>
+
+/*
+ * Define DEBUG_XBUS before including this header to get debug prints from this
+ * unit
+ */
+
+#define XBUS_LANE_COUNT 17
+
+#define XBUS_LINK_GROUP_OFFSET 0x2000000000
+
+/*
+ * The API below is meant to be used after SBE for the second CPU is up (so
+ * after istep 8.4), but prior to XSCOM working for it, which covers range of
+ * isteps that initialize XBus and SMP.
+ *
+ * The functions use XSCOM for the first CPU and SBE IO for the second one. When
+ * SCOM address targets XBus chiplet, ring part of the address is updated to
+ * XBus link #1 if necessary (addresses in code use link #0, which also matches
+ * Hostboot logs).
+ *
+ * No need to use this interface once Powerbus is activated (after istep 10.1)
+ * and XSCOM can access SCOMs on both CPUs.
+ */
+
+void put_scom(uint8_t chip, uint64_t addr, uint64_t data);
+uint64_t get_scom(uint8_t chip, uint64_t addr);
+
+#ifdef DEBUG_XBUS
+#include <console/console.h>
+
+#define put_scom(c, x, y)                                                      \
+({                                                                             \
+	uint8_t __cw = c;                                                      \
+	uint64_t __xw = x;                                                     \
+	uint64_t __yw = y;                                                     \
+	printk(BIOS_EMERG, "PUTSCOM %d %016llX %016llX\n", __cw, __xw, __yw);  \
+	put_scom(__cw, __xw, __yw);                                            \
+})
+
+#define get_scom(c, x)                                                         \
+({                                                                             \
+	uint8_t __cr  = c;                                                     \
+	uint64_t __xr = x;                                                     \
+	uint64_t __yr = get_scom(__cr, __xr);                                  \
+	printk(BIOS_EMERG, "GETSCOM %d %016llX %016llX\n", __cr, __xr, __yr);  \
+	__yr;                                                                  \
+})
+
+#endif
+
+static inline void and_scom(uint8_t chip, uint64_t addr, uint64_t mask)
+{
+	put_scom(chip, addr, get_scom(chip, addr) & mask);
+}
+
+static inline void or_scom(uint8_t chip, uint64_t addr, uint64_t mask)
+{
+	put_scom(chip, addr, get_scom(chip, addr) | mask);
+}
+
+static inline void and_or_scom(uint8_t chip, uint64_t addr, uint64_t and, uint64_t or)
+{
+	uint64_t data = get_scom(chip, addr);
+	data &= and;
+	data |= or;
+	put_scom(chip, addr, data);
+}
+
+#endif /* __SOC_IBM_POWER9_XBUS_H */


### PR DESCRIPTION
This contains implementation of relevant parts of isteps 9.2, 9.4, 9.6 and 9.7 (XBus only, no OBus). The rest of 9.* isteps group are either empty (debug stuff only, 9.3 and 9.5), not required at least at this point (lane repair information in 9.1) or don't apply (link aggregation in 9.8 doesn't seem to be our case).

Based on PR #65