### PR TITLE
mb/clevo/tgl-u/variants/nv41mz/devicetree.cb: set HDA subsystem ID

### DIFF
--- a/src/mainboard/clevo/tgl-u/Kconfig
+++ b/src/mainboard/clevo/tgl-u/Kconfig
@@ -41,14 +41,6 @@ config MAINBOARD_FAMILY
 	string
 	default "Clevo_tgl-u"
 
-config SUBSYSTEM_VENDOR_ID
-	hex
-	default 0x1558
-
-config SUBSYSTEM_DEVICE_ID
-	hex
-	default 0x4018
-
 config MAX_CPUS
 	int
 	default 8

--- a/src/mainboard/clevo/tgl-u/variants/nv41mz/devicetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/nv41mz/devicetree.cb
@@ -350,6 +350,7 @@ chip soc/intel/tigerlake
 			end
 		end
 		device ref hda on
+			subsystemid 0x1558 0x4019
 			register "PchHdaAudioLinkHdaEnable" = "1"
 			register "PchHdaAudioLinkDmicEnable[0]" = "1"
 			register "PchHdaAudioLinkDmicEnable[1]" = "0"

--- a/src/mainboard/clevo/tgl-u/variants/nv41mz/devicetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/nv41mz/devicetree.cb
@@ -98,6 +98,8 @@ chip soc/intel/tigerlake
 	end
 
 	device domain 0 on
+		subsystemid 0x1558 0x4018 inherit
+
 		#From CPU EDS(575683)
 		device ref system_agent on end
 		device ref igpu on


### PR DESCRIPTION
Set correct subsystem ID for HD Audio device.
Needed for Windows drivers to load correct jack configuration.
Fixes [microphone input on Windows.](https://gitlab.com/novacustom/dasharo-compatibility/-/issues/15#note_822393261)

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>