### PR TITLE
Clevo nv41mz/smbios fixes

### DIFF
--- a/src/mainboard/clevo/tgl-u/Kconfig
+++ b/src/mainboard/clevo/tgl-u/Kconfig
@@ -39,7 +39,7 @@ config MAINBOARD_PART_NUMBER
 
 config MAINBOARD_FAMILY
 	string
-	default "Clevo_tgl-u"
+	default "Not Applicable" # Match stock firmware
 
 config SUBSYSTEM_VENDOR_ID
 	hex

--- a/src/mainboard/clevo/tgl-u/mainboard.c
+++ b/src/mainboard/clevo/tgl-u/mainboard.c
@@ -8,6 +8,11 @@
 #include <smbios.h>
 #include <string.h>
 
+const char *smbios_system_sku(void)
+{
+	return "Not Applicable";
+}
+
 static void mainboard_init(void *chip_info)
 {
 	const struct pad_config *pads;

--- a/src/mainboard/clevo/tgl-u/mainboard.c
+++ b/src/mainboard/clevo/tgl-u/mainboard.c
@@ -13,6 +13,11 @@ const char *smbios_system_sku(void)
 	return "Not Applicable";
 }
 
+smbios_enclosure_type smbios_mainboard_enclosure_type(void)
+{
+	return SMBIOS_ENCLOSURE_NOTEBOOK;
+}
+
 static void mainboard_init(void *chip_info)
 {
 	const struct pad_config *pads;


### PR DESCRIPTION
Match the DMI fields of stock Insyde firmware.

Results in all hwids in fwupdtool being the same as in stock firmware - except the ones which include BIOS version and vendor:

```
user@user-NV4XMB-ME-MZ:~$ diff <(sudo fwupdtool hwids) <(cat hwids_stock.log)
3,6c3,6
< BiosVendor: 3mdeb Embedded Systems Consulting
< BiosVersion: Dasharo (coreboot+UEFI) v1.0.0
< BiosMajorRelease: 1
< BiosMinorRelease: 0
---
> BiosVendor: INSYDE Corp.
> BiosVersion: 1.07.06N
> BiosMajorRelease: 7
> BiosMinorRelease: 6
17,19c17,19
< {37b192b9-4fe8-5d20-b4e7-6d00782e2a09}   <- Manufacturer + Family + ProductName + ProductSku + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
< {bc90b4cf-a507-50c5-bf51-48c26863dc13}   <- Manufacturer + Family + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
< {cf004452-c518-5899-a791-d246db94c413}   <- Manufacturer + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
---
> {86a91a69-dd25-5408-bfa2-40fe2ad60bd3}   <- Manufacturer + Family + ProductName + ProductSku + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
> {5423c865-3010-5c58-812b-4a4063c63118}   <- Manufacturer + Family + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
> {a71162ca-9f64-5a36-9334-e184f5387eea}   <- Manufacturer + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
```