### PR TITLE
soc/power9/mvpd.c: cache MVPD in memory between stages

### DIFF
--- a/src/include/symbols.h
+++ b/src/include/symbols.h
@@ -76,6 +76,7 @@ DECLARE_REGION(pdpt)
 DECLARE_OPTIONAL_REGION(opensbi)
 DECLARE_OPTIONAL_REGION(bl31)
 DECLARE_REGION(transfer_buffer)
+DECLARE_REGION(mvpd_cache)
 
 /* Returns true when pre-RAM symbols are known to the linker.
  * (Does not necessarily mean that the memory is accessible.) */

--- a/src/mainboard/raptor-cs/talos-2/memlayout.ld
+++ b/src/mainboard/raptor-cs/talos-2/memlayout.ld
@@ -66,12 +66,14 @@ SECTIONS
 
 	ROMSTAGE(            0xF8240000, 256K)
 
+	REGION(mvpd_cache,   0xF8280000, 128K, 8)
+
 	/*
 	 * bootblock_crt0.S assumes this is the last part of L3, leaving for
 	 * interrupt vectors at least 0.5M because of cache associativity. If
 	 * more CBFS_CACHE is needed, split this into pre-/postram caches.
 	 */
-	CBFS_CACHE(          0xF8280000, 7M)
+	CBFS_CACHE(          0xF8380000, 6M)
 
 	RAMSTAGE(            0xF9000000, 2M)
 

--- a/src/soc/ibm/power9/mvpd.c
+++ b/src/soc/ibm/power9/mvpd.c
@@ -10,6 +10,7 @@
 #include <endian.h>
 #include <stdint.h>
 #include <string.h>
+#include <symbols.h>
 
 #include "tor.h"
 #include "rs4.h"
@@ -205,11 +206,7 @@ static bool eeprom_extract_kwd(uint8_t cpu, uint64_t offset, uint8_t index,
  * already built one */
 static const uint8_t *mvpd_get(uint8_t cpu)
 {
-	/* Actual size of MVPD is a bit less than 42 KiB while maximum is 64
-	 * KiB, save some memory */
-	enum { MVPD_SIZE = 42 * KiB };
-
-	static uint8_t mvpd_bufs[2][MVPD_SIZE];
+	enum { MAX_MVPD_SIZE = 64 * KiB };
 
 	const char *mvpd_records[] = {
 		"CRP0", "CP00", "VINI",
@@ -218,7 +215,7 @@ static const uint8_t *mvpd_get(uint8_t cpu)
 		"VRML", "VWML", "VER0", "MER0", "VMSC",
 	};
 
-	uint8_t *mvpd_buf = mvpd_bufs[cpu];
+	uint8_t *mvpd_buf = &_mvpd_cache[cpu * MAX_MVPD_SIZE];
 
 	struct mvpd_toc_entry *toc = (void *)mvpd_buf;
 	uint16_t mvpd_offset = MVPD_TOC_SIZE;
@@ -281,7 +278,7 @@ static const uint8_t *mvpd_get(uint8_t cpu)
 			if (k == ARRAY_SIZE(mvpd_records))
 				continue;
 
-			if (mvpd_offset + record_size > MVPD_SIZE)
+			if (mvpd_offset + record_size > MAX_MVPD_SIZE)
 				die("MVPD section doesn't have space for %.4s record of size %d\n",
 				    record_name, record_size);
 


### PR DESCRIPTION
MVPD is now read only once per CPU. I haven't checked how much time this saves exactly due to big fluctuations of serial output, but it is noticeably faster.