### PR TITLE
mb/clevo/tgl-u: windows fixes

### DIFF
--- a/src/drivers/pc80/tpm/tis.c
+++ b/src/drivers/pc80/tpm/tis.c
@@ -780,10 +780,7 @@ static void lpc_tpm_fill_ssdt(const struct device *dev)
 	const char *path = acpi_device_path(dev->bus->dev);
 	tpm_config_t *config = (tpm_config_t *)dev->chip_info;
 
-	if (!path) {
-		path = "\\_SB_.PCI0.LPCB";
-		printk(BIOS_DEBUG, "Using default TPM ACPI path: '%s'\n", path);
-	}
+	path = "\\_SB_.PCI0";
 
 	/* Device */
 	acpigen_write_scope(path);

--- a/src/mainboard/clevo/tgl-u/variants/baseboard/devicetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/baseboard/devicetree.cb
@@ -131,7 +131,6 @@ chip soc/intel/tigerlake
 		end
 		device ref pch_espi on
 			chip drivers/pc80/tpm
-				register "irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_C14)"
 				device pnp 0c31.0 on end
 			end
 		end

--- a/src/mainboard/clevo/tgl-u/variants/baseboard/devicetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/baseboard/devicetree.cb
@@ -124,11 +124,6 @@ chip soc/intel/tigerlake
 				end
 			end
 		end
-		device ref hda on
-			register "PchHdaAudioLinkHdaEnable" = "1"
-			register "PchHdaAudioLinkDmicEnable[0]" = "1"
-			register "PchHdaAudioLinkDmicEnable[1]" = "0"
-		end
 		device ref pch_espi on
 			chip drivers/pc80/tpm
 				device pnp 0c31.0 on end

--- a/src/mainboard/clevo/tgl-u/variants/ns50mu/overridetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/ns50mu/overridetree.cb
@@ -217,5 +217,10 @@ chip soc/intel/tigerlake
 				register "fans[0].curve.speed" = "{ 16, 25, 50, 100 }"
 			end
 		end
+		device ref hda on
+			register "PchHdaAudioLinkHdaEnable" = "1"
+			register "PchHdaAudioLinkDmicEnable[0]" = "1"
+			register "PchHdaAudioLinkDmicEnable[1]" = "0"
+		end
 	end
 end

--- a/src/mainboard/clevo/tgl-u/variants/nv41mz/overridetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/nv41mz/overridetree.cb
@@ -225,5 +225,11 @@ chip soc/intel/tigerlake
 				register "fans[1].curve.speed" = "{ 16, 25, 50, 100 }"
 			end
 		end
+		device ref hda on
+			subsystemid 0x1558 0x4019
+			register "PchHdaAudioLinkHdaEnable" = "1"
+			register "PchHdaAudioLinkDmicEnable[0]" = "1"
+			register "PchHdaAudioLinkDmicEnable[1]" = "0"
+		end
 	end
 end


### PR DESCRIPTION
- move hda device to overridetrees to fix SSID setting
- remove TPM IRQ setting from devicetree
- use hardcoded TPM path recognized by Windows

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>