### PR TITLE
soc/intel/tigerlake: hide IOM and PMC devices in ACPI

### DIFF
--- a/src/soc/intel/tigerlake/acpi/tcss.asl
+++ b/src/soc/intel/tigerlake/acpi/tcss.asl
@@ -323,6 +323,7 @@ Scope (\_SB.PCI0)
 		Name (_CRS, ResourceTemplate () {
 			Memory32Fixed (ReadWrite, IOM_BASE_ADDRESS, IOM_BASE_SIZE)
 		})
+		Name (_STA, 0xB)
 	}
 
 	/*

--- a/src/soc/intel/tigerlake/pmc.c
+++ b/src/soc/intel/tigerlake/pmc.c
@@ -106,6 +106,7 @@ static void soc_pmc_fill_ssdt(const struct device *dev)
 
 	acpigen_write_name_string("_HID", PMC_HID);
 	acpigen_write_name_string("_DDN", "Intel(R) Tiger Lake IPC Controller");
+	acpigen_write_STA(ACPI_STATUS_DEVICE_HIDDEN_ON);
 
 	/*
 	 * Part of the PCH's reserved 32 MB MMIO range (0xFC800000 - 0xFE7FFFFF).


### PR DESCRIPTION
Hide devices that appear as `Unknown Devices` in Windows Device Manager.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>