### PR TITLE
Start OCC for the second CPU

### DIFF
--- a/src/include/cpu/power/occ.h
+++ b/src/include/cpu/power/occ.h
@@ -5,14 +5,14 @@
 
 #include <stdint.h>
 
-void writeOCCSRAM(uint32_t address, uint64_t *buffer, size_t data_length);
-void readOCCSRAM(uint32_t address, uint64_t *buffer, size_t data_length);
-void write_occ_command(uint64_t write_data);
-void clear_occ_special_wakeups(uint64_t cores);
-void special_occ_wakeup_disable(uint64_t cores);
-void occ_start_from_mem(void);
+void writeOCCSRAM(uint8_t chip, uint32_t address, uint64_t *buffer, size_t data_length);
+void readOCCSRAM(uint8_t chip, uint32_t address, uint64_t *buffer, size_t data_length);
+void write_occ_command(uint8_t chip, uint64_t write_data);
+void clear_occ_special_wakeups(uint8_t chip, uint64_t cores);
+void special_occ_wakeup_disable(uint8_t chip, uint64_t cores);
+void occ_start_from_mem(uint8_t chip);
 
-void pm_occ_fir_init(void);
-void pm_pba_fir_init(void);
+void pm_occ_fir_init(uint8_t chip);
+void pm_pba_fir_init(uint8_t chip);
 
 #endif /* CPU_PPC64_OCC_H */

--- a/src/lib/device_tree.c
+++ b/src/lib/device_tree.c
@@ -554,7 +554,7 @@ struct device_tree_node *dt_find_node(struct device_tree_node *parent,
 		if (!create)
 			return NULL;
 
-		found = malloc(sizeof(*found));
+		found = calloc(1, sizeof(*found));
 		if (!found)
 			return NULL;
 		found->name = strdup(*path);

--- a/src/mainboard/raptor-cs/talos-2/Kconfig
+++ b/src/mainboard/raptor-cs/talos-2/Kconfig
@@ -40,6 +40,10 @@ config MAINBOARD_DIR
 	string
 	default "raptor-cs/talos-2"
 
+config HEAP_SIZE
+	hex
+	default 0x200000
+
 config MAINBOARD_PART_NUMBER
 	string
 	default "Talos II"

--- a/src/mainboard/raptor-cs/talos-2/memlayout.ld
+++ b/src/mainboard/raptor-cs/talos-2/memlayout.ld
@@ -75,6 +75,6 @@ SECTIONS
 	 */
 	CBFS_CACHE(          0xF8380000, 6M)
 
-	RAMSTAGE(            0xF9000000, 2M)
+	RAMSTAGE(            0xF9000000, 3M)
 
 }

--- a/src/soc/ibm/power9/homer.c
+++ b/src/soc/ibm/power9/homer.c
@@ -2479,45 +2479,55 @@ static void set_occ_active_state(uint8_t chip, struct homer_st *homer)
 }
 
 /* Moves OCC to active state */
-static void activate_occ(uint8_t chip, struct homer_st *homer)
+static void activate_occ(uint8_t chips, struct homer_st *homers)
 {
-	/* TODO: Hostboot performs each step below for every OCC before moving
-	 *       to the next step (looks like performing it for master OCC
-	 *       first), so might need to loop over every OCC in inside each
-	 *       function below. All this after starting PM complex for every
-	 *       chip outside of this function. */
-
-	struct occ_poll_response poll_response;
-
 	/* Make sure OCCs are ready for communication */
-	wait_for_occ_checkpoint(chip);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			wait_for_occ_checkpoint(chip);
+	}
 
 	/* Send initial poll to all OCCs to establish communication */
-	poll_occ(chip, homer, /*flush_all_errors=*/false, &poll_response);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip)) {
+			struct occ_poll_response poll_response;
+			poll_occ(chip, &homers[chip], /*flush_all_errors=*/false,
+				 &poll_response);
+		}
+	}
 
 	/* Send OCC's config data */
-	send_occ_config_data(chip, homer);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			send_occ_config_data(chip, &homers[chip]);
+	}
 
-	/* Set the User PCAP */
-	send_occ_user_power_cap(chip, homer);
+	/* Set the User PCAP (sent only to master OCC) */
+	send_occ_user_power_cap(/*chip=*/0, &homers[0]);
 
-	/* Switch for OCC to active state */
-	set_occ_active_state(chip, homer);
+	/* Switch for OCC to active state (sent only to master OCC) */
+	set_occ_active_state(/*chip=*/0, &homers[0]);
 
-	/* Hostboot sets active sensors for all OCCs here, so BMC can start
+	/* TODO: Hostboot sets active sensors for all OCCs here, so BMC can start
 	 * communication with OCCs. */
 }
 
-static void istep_21_1(uint8_t chip, struct homer_st *homer, uint64_t cores)
+static void istep_21_1(uint8_t chips, struct homer_st *homers, const uint64_t *cores)
 {
-	load_pm_complex(chip, homer);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			load_pm_complex(chip, &homers[chip]);
+	}
 
 	printk(BIOS_ERR, "Starting PM complex...\n");
-	start_pm_complex(chip, homer, cores);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			start_pm_complex(chip, &homers[chip], cores[chip]);
+	}
 	printk(BIOS_ERR, "Done starting PM complex\n");
 
 	printk(BIOS_ERR, "Activating OCC...\n");
-	activate_occ(chip, homer);
+	activate_occ(chips, homers);
 	printk(BIOS_ERR, "Done activating OCC\n");
 }
 
@@ -3587,8 +3597,7 @@ void build_homer_image(void *homer_bar, void *common_occ_area, uint64_t nominal_
 	}
 
 	/* Boot OCC here and activate SGPE at the same time */
-	/* TODO: initialize OCC for the second CPU when it's present */
-	istep_21_1(/*chip=*/0, homer, cores[0]);
+	istep_21_1(chips, homer, cores);
 
 	istep_16_1(this_core);
 }

--- a/src/soc/ibm/power9/homer.c
+++ b/src/soc/ibm/power9/homer.c
@@ -3563,14 +3563,28 @@ void build_homer_image(void *homer_bar, void *common_occ_area, uint64_t nominal_
 		nominal_freq[chip] = get_voltage_data(chip)->nominal.freq * MHz;
 	}
 
-	setup_wakeup_mode(/*chip=*/0, cores[0]);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			setup_wakeup_mode(chip, cores[chip]);
+	}
 
 	report_istep(15,2);
-	istep_15_2(/*chip=*/0, &homer[0], common_occ_area);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			istep_15_2(chip, &homer[chip], common_occ_area);
+	}
+
 	report_istep(15,3);
-	istep_15_3(/*chip=*/0, cores[0]);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			istep_15_3(chip, cores[chip]);
+	}
+
 	report_istep(15,4);
-	istep_15_4(/*chip=*/0, cores[0]);
+	for (uint8_t chip = 0; chip < MAX_CHIPS; chip++) {
+		if (chips & (1 << chip))
+			istep_15_4(chip, cores[chip]);
+	}
 
 	/* Boot OCC here and activate SGPE at the same time */
 	/* TODO: initialize OCC for the second CPU when it's present */

--- a/src/soc/ibm/power9/homer.c
+++ b/src/soc/ibm/power9/homer.c
@@ -1499,7 +1499,7 @@ static void pm_pss_init(uint8_t chip)
 	 */
 	rscom_and_or(chip, PU_SPIPSS_ADC_CTRL_REG0,
 		     ~PPC_BITMASK(0, 5) & ~PPC_BITMASK(12, 17),
-		     PPC_PLACE(8, 0, 6));
+		     PPC_PLACE(0x20, 0, 6));
 
 	/*
 	 *  0     adc_fsm_enable    = 1
@@ -1527,7 +1527,7 @@ static void pm_pss_init(uint8_t chip)
 	 */
 	rscom_and_or(chip, PU_SPIPSS_P2S_CTRL_REG0,
 		     ~PPC_BITMASK(0, 5) & ~PPC_BITMASK(12, 17),
-		     PPC_PLACE(8, 0, 6));
+		     PPC_PLACE(0x20, 0, 6));
 
 	/*
 	 *  0     p2s_fsm_enable    = 1

--- a/src/soc/ibm/power9/homer.c
+++ b/src/soc/ibm/power9/homer.c
@@ -894,7 +894,7 @@ static void pba_reset(uint8_t chip)
 	pba_slave_setup_runtime_phase(chip);
 }
 
-static void stop_gpe_init(struct homer_st *homer)
+static void stop_gpe_init(uint8_t chip, struct homer_st *homer)
 {
 	/* First check if SGPE_ACTIVE is not set in OCCFLAG register
 	if (TP.TPCHIP.OCC.OCI.OCB.OCB_OCI_OCCFLG[8] == 1):        // 0x0006C08A
@@ -902,9 +902,9 @@ static void stop_gpe_init(struct homer_st *homer)
 		[all] 0
 		[8]   1       // SGPE_ACTIVE, bits in this register are defined by OCC firmware
 	*/
-	if (read_scom(0x0006C08A) & PPC_BIT(8)) {
+	if (read_rscom(chip, 0x0006C08A) & PPC_BIT(8)) {
 		printk(BIOS_WARNING, "SGPE_ACTIVE is set in OCCFLAG register, clearing it\n");
-		write_scom(0x0006C08B, PPC_BIT(8));
+		write_rscom(chip, 0x0006C08B, PPC_BIT(8));
 	}
 
 	/*
@@ -917,7 +917,7 @@ static void stop_gpe_init(struct homer_st *homer)
 	*/
 	uint32_t ivpr = 0x80000000 + homer->qpmr.sgpe.header.l1_offset +
 	                offsetof(struct homer_st, qpmr);
-	write_scom(0x00066001, PPC_PLACE(ivpr, 0, 32));
+	write_rscom(chip, 0x00066001, PPC_PLACE(ivpr, 0, 32));
 
 	/* Program XCR to ACTIVATE SGPE
 	TP.TPCHIP.OCC.OCI.GPE3.GPENXIXCR                          // 0x00066010
@@ -930,9 +930,9 @@ static void stop_gpe_init(struct homer_st *homer)
 	  [all] 0
 	  [1-3] PPE_XIXCR_XCR = 2     // resume
 	*/
-	write_scom(0x00066010, PPC_PLACE(6, 1, 3));
-	write_scom(0x00066010, PPC_PLACE(4, 1, 3));
-	write_scom(0x00066010, PPC_PLACE(2, 1, 3));
+	write_rscom(chip, 0x00066010, PPC_PLACE(6, 1, 3));
+	write_rscom(chip, 0x00066010, PPC_PLACE(4, 1, 3));
+	write_rscom(chip, 0x00066010, PPC_PLACE(2, 1, 3));
 
 	/*
 	 * Now wait for SGPE to not be halted and for the HCode to indicate to be
@@ -945,8 +945,8 @@ static void stop_gpe_init(struct homer_st *homer)
 	  if ((TP.TPCHIP.OCC.OCI.OCB.OCB_OCI_OCCFLG[8] == 1) &&     // 0x0006C08A
 		  (TP.TPCHIP.OCC.OCI.GPE3.GPEXIXSR[0] == 0)): break     // 0x00066021
 	*/
-	long time = wait_us(125*20, ((read_scom(0x0006C08A) & PPC_BIT(8)) &&
-	                             !(read_scom(0x00066021) & PPC_BIT(0))));
+	long time = wait_us(125*20, ((read_rscom(chip, 0x0006C08A) & PPC_BIT(8)) &&
+	                             !(read_rscom(chip, 0x00066021) & PPC_BIT(0))));
 
 	if (!time)
 		die("Timeout while waiting for SGPE activation\n");
@@ -1201,7 +1201,7 @@ static void load_pm_complex(uint8_t chip, struct homer_st *homer)
 	load_host_data_to_homer(chip, homer);
 }
 
-static void pm_corequad_init(uint64_t cores)
+static void pm_corequad_init(uint8_t chip, uint64_t cores)
 {
 	enum {
 		EQ_QPPM_QPMMR_CLEAR = 0x100F0104,
@@ -1240,33 +1240,33 @@ static void pm_corequad_init(uint64_t cores)
 		 * 18 - 19    : PCB interrupt
 		 * 20,22,24,26: InterPPM Ivrm/Aclk/Vdata/Dpll enable
 		 */
-		write_scom_for_chiplet(quad_chiplet, EQ_QPPM_QPMMR_CLEAR,
-				       PPC_BIT(0) |
-				       PPC_BITMASK(1, 11) |
-				       PPC_BIT(12) |
-				       PPC_BIT(13) |
-				       PPC_BIT(14) |
-				       PPC_BITMASK(18, 19) |
-				       PPC_BIT(20) |
-				       PPC_BIT(22) |
-				       PPC_BIT(24) |
-				       PPC_BIT(26));
+		write_rscom_for_chiplet(chip, quad_chiplet, EQ_QPPM_QPMMR_CLEAR,
+					PPC_BIT(0) |
+					PPC_BITMASK(1, 11) |
+					PPC_BIT(12) |
+					PPC_BIT(13) |
+					PPC_BIT(14) |
+					PPC_BITMASK(18, 19) |
+					PPC_BIT(20) |
+					PPC_BIT(22) |
+					PPC_BIT(24) |
+					PPC_BIT(26));
 
 		/* Clear QUAD PPM ERROR Register */
-		write_scom_for_chiplet(quad_chiplet, EQ_QPPM_ERR, 0);
+		write_rscom_for_chiplet(chip, quad_chiplet, EQ_QPPM_ERR, 0);
 
 		/* Restore Quad PPM Error Mask */
 		err_mask = 0xFFFFFF00; // from Hostboot's log
-		write_scom_for_chiplet(quad_chiplet, EQ_QPPM_ERRMSK,
-				       PPC_PLACE(err_mask, 0, 32));
+		write_rscom_for_chiplet(chip, quad_chiplet, EQ_QPPM_ERRMSK,
+					PPC_PLACE(err_mask, 0, 32));
 
 		for (int core = quad * 4; core < (quad + 1) * 4; ++core) {
 			chiplet_id_t core_chiplet = EC00_CHIPLET_ID + core;
 
 			/* Clear the Core PPM CME DoorBells */
 			for (int i = 0; i < DOORBELLS_COUNT; ++i)
-				write_scom_for_chiplet(core_chiplet, CME_DOORBELL_CLEAR[i],
-						       PPC_BITMASK(0, 63));
+				write_rscom_for_chiplet(chip, core_chiplet, CME_DOORBELL_CLEAR[i],
+							PPC_BITMASK(0, 63));
 
 			/*
 			 * Setup Core PPM Mode register
@@ -1285,15 +1285,15 @@ static void pm_corequad_init(uint64_t cores)
 			 * 10     : STOP_EXIT_TYPE_SEL
 			 * 13     : WKUP_NOTIFY_SELECT
 			 */
-			write_scom_for_chiplet(core_chiplet, C_CPPM_CPMMR_CLEAR,
-					       PPC_BIT(1) |
-					       PPC_BIT(11) |
-					       PPC_BIT(12) |
-					       PPC_BIT(14) |
-					       PPC_BIT(15));
+			write_rscom_for_chiplet(chip, core_chiplet, C_CPPM_CPMMR_CLEAR,
+						PPC_BIT(1) |
+						PPC_BIT(11) |
+						PPC_BIT(12) |
+						PPC_BIT(14) |
+						PPC_BIT(15));
 
 			/* Clear Core PPM Errors */
-			write_scom_for_chiplet(core_chiplet, C_CPPM_ERR, 0);
+			write_rscom_for_chiplet(chip, core_chiplet, C_CPPM_ERR, 0);
 
 			/*
 			 * Clear Hcode Error Injection and other CSAR settings:
@@ -1306,21 +1306,21 @@ static void pm_corequad_init(uint64_t cores)
 			 * DISABLE_CME_NACK_ON_PROLONGED_DROOP is NOT cleared
 			 * as this is a persistent, characterization setting.
 			 */
-			write_scom_for_chiplet(core_chiplet, C_CPPM_CSAR_CLEAR,
-					       PPC_BIT(27) |
-					       PPC_BIT(28) |
-					       PPC_BIT(30) |
-					       PPC_BIT(31));
+			write_rscom_for_chiplet(chip, core_chiplet, C_CPPM_CSAR_CLEAR,
+						PPC_BIT(27) |
+						PPC_BIT(28) |
+						PPC_BIT(30) |
+						PPC_BIT(31));
 
 			/* Restore CORE PPM Error Mask */
 			err_mask = 0xFFF00000; // from Hostboot's log
-			write_scom_for_chiplet(core_chiplet, C_CPPM_ERRMSK,
-					       PPC_PLACE(err_mask, 0, 32));
+			write_rscom_for_chiplet(chip, core_chiplet, C_CPPM_ERRMSK,
+						PPC_PLACE(err_mask, 0, 32));
 		}
 	}
 }
 
-static void pstate_gpe_init(struct homer_st *homer, uint64_t cores)
+static void pstate_gpe_init(uint8_t chip, struct homer_st *homer, uint64_t cores)
 {
 	enum {
 		/* The following constants hold approximate values */
@@ -1359,32 +1359,32 @@ static void pstate_gpe_init(struct homer_st *homer, uint64_t cores)
 	uint8_t avsbus_rail = 0;
 
 	uint64_t ivpr = 0x80000000 + offsetof(struct homer_st, ppmr.l1_bootloader);
-	write_scom(PU_GPE2_GPEIVPR_SCOM, ivpr << 32);
+	write_rscom(chip, PU_GPE2_GPEIVPR_SCOM, ivpr << 32);
 
 	/* Set up the OCC Scratch 2 register before PGPE boot */
-	occ_scratch = read_scom(PU_OCB_OCI_OCCS2_SCOM);
+	occ_scratch = read_rscom(chip, PU_OCB_OCI_OCCS2_SCOM);
 	occ_scratch &= ~PPC_BIT(PGPE_ACTIVE);
 	occ_scratch &= ~PPC_BITMASK(27, 32);
 	occ_scratch |= PPC_PLACE(avsbus_number, 27, 1);
 	occ_scratch |= PPC_PLACE(avsbus_rail, 28, 4);
-	write_scom(PU_OCB_OCI_OCCS2_SCOM, occ_scratch);
+	write_rscom(chip, PU_OCB_OCI_OCCS2_SCOM, occ_scratch);
 
-	write_scom(PU_GPE2_GPETSEL_SCOM, 0x1A00000000000000);
+	write_rscom(chip, PU_GPE2_GPETSEL_SCOM, 0x1A00000000000000);
 
 	/* OCCFLG2_PGPE_HCODE_FIT_ERR_INJ | OCCFLG2_PGPE_HCODE_PSTATE_REQ_ERR_INJ */
-	write_scom(PU_OCB_OCI_OCCFLG2_CLEAR, 0x1100000000);
+	write_rscom(chip, PU_OCB_OCI_OCCFLG2_CLEAR, 0x1100000000);
 
 	printk(BIOS_ERR, "Attempting PGPE activation...\n");
 
-	write_scom(PU_GPE2_PPE_XIXCR, PPC_PLACE(HARD_RESET, 1, 3));
-	write_scom(PU_GPE2_PPE_XIXCR, PPC_PLACE(TOGGLE_XSR_TRH, 1, 3));
-	write_scom(PU_GPE2_PPE_XIXCR, PPC_PLACE(RESUME, 1, 3));
+	write_rscom(chip, PU_GPE2_PPE_XIXCR, PPC_PLACE(HARD_RESET, 1, 3));
+	write_rscom(chip, PU_GPE2_PPE_XIXCR, PPC_PLACE(TOGGLE_XSR_TRH, 1, 3));
+	write_rscom(chip, PU_GPE2_PPE_XIXCR, PPC_PLACE(RESUME, 1, 3));
 
 	wait_ms(PGPE_POLLTIME_MS * TIMEOUT_COUNT,
-		(read_scom(PU_OCB_OCI_OCCS2_SCOM) & PPC_BIT(PGPE_ACTIVE)) ||
-		(read_scom(PU_GPE2_PPE_XIDBGPRO) & PPC_BIT(HALTED_STATE)));
+		(read_rscom(chip, PU_OCB_OCI_OCCS2_SCOM) & PPC_BIT(PGPE_ACTIVE)) ||
+		(read_rscom(chip, PU_GPE2_PPE_XIDBGPRO) & PPC_BIT(HALTED_STATE)));
 
-	if (read_scom(PU_OCB_OCI_OCCS2_SCOM) & PPC_BIT(PGPE_ACTIVE))
+	if (read_rscom(chip, PU_OCB_OCI_OCCS2_SCOM) & PPC_BIT(PGPE_ACTIVE))
 		printk(BIOS_ERR, "PGPE was activated successfully\n");
 	else
 		die("Failed to activate PGPE\n");
@@ -1399,9 +1399,9 @@ static void pstate_gpe_init(struct homer_st *homer, uint64_t cores)
 		if (!IS_EQ_FUNCTIONAL(quad, cores))
 			continue;
 
-		scom_and_or_for_chiplet(EP00_CHIPLET_ID + quad, EQ_QPPM_QPMMR,
-					~PPC_BITMASK(1, 11),
-					PPC_PLACE(safe_mode_freq, 1, 11));
+		rscom_and_or_for_chiplet(chip, EP00_CHIPLET_ID + quad, EQ_QPPM_QPMMR,
+					 ~PPC_BITMASK(1, 11),
+					 PPC_PLACE(safe_mode_freq, 1, 11));
 	}
 }
 
@@ -1427,9 +1427,9 @@ static void pm_pba_init(uint8_t chip)
 	uint8_t attr_pbax_broadcast_vector = 0;
 
 	/* Assuming ATTR_CHIP_EC_FEATURE_HW423589_OPTION1 == true */
-	write_scom(PU_PBACFG, PPC_BIT(PU_PBACFG_CHSW_DIS_GROUP_SCOPE));
+	write_rscom(chip, PU_PBACFG, PPC_BIT(PU_PBACFG_CHSW_DIS_GROUP_SCOPE));
 
-	write_scom(PU_PBAFIR, 0);
+	write_rscom(chip, PU_PBAFIR, 0);
 
 	data |= PPC_PLACE(attr_pbax_groupid, 4, 4);
 	data |= PPC_PLACE(attr_pbax_chipid, 8, 3);
@@ -1438,17 +1438,17 @@ static void pm_pba_init(uint8_t chip)
 	data |= PPC_PLACE(PBAX_SND_RETRY_COMMIT_OVERCOMMIT, 27, 1);
 	data |= PPC_PLACE(PBAX_SND_RETRY_THRESHOLD, 28, 8);
 	data |= PPC_PLACE(PBAX_SND_TIMEOUT, 36, 5);
-	write_scom(PU_PBAXCFG_SCOM, data);
+	write_rscom(chip, PU_PBAXCFG_SCOM, data);
 }
 
 static void pm_pstate_gpe_init(uint8_t chip, struct homer_st *homer, uint64_t cores)
 {
-	pstate_gpe_init(homer, cores);
+	pstate_gpe_init(chip, homer, cores);
 	pm_pba_init(chip);
 }
 
 /* Generates host configuration vector and updates the value in HOMER */
-static void check_proc_config(struct homer_st *homer)
+static void check_proc_config(uint8_t chip, struct homer_st *homer)
 {
 	uint64_t vector_value = INIT_CONFIG_VALUE;
 	uint64_t *conf_vector = (void *)((uint8_t *)&homer->qpmr + QPMR_PROC_CONFIG_POS);
@@ -1459,8 +1459,8 @@ static void check_proc_config(struct homer_st *homer)
 		chiplet_id_t nest = mcs_to_nest[mcs_ids[mcs_i]];
 
 		/* MCS_MCFGP and MCS_MCFGPM registers are undocumented, see istep 14.5. */
-		if ((read_scom_for_chiplet(nest, 0x0501080A) & PPC_BIT(0)) ||
-		    (read_scom_for_chiplet(nest, 0x0501080C) & PPC_BIT(0))) {
+		if ((read_rscom_for_chiplet(chip, nest, 0x0501080A) & PPC_BIT(0)) ||
+		    (read_rscom_for_chiplet(chip, nest, 0x0501080C) & PPC_BIT(0))) {
 			uint8_t pos = MCS_POS + mcs_i;
 			*conf_vector |= PPC_BIT(pos);
 
@@ -1490,9 +1490,9 @@ static void pm_pss_init(uint8_t chip)
 	 *  0-5   frame size
 	 * 12-17  in delay
 	 */
-	scom_and_or(PU_SPIPSS_ADC_CTRL_REG0,
-		    ~PPC_BITMASK(0, 5) & ~PPC_BITMASK(12, 17),
-		    PPC_PLACE(8, 0, 6));
+	rscom_and_or(chip, PU_SPIPSS_ADC_CTRL_REG0,
+		     ~PPC_BITMASK(0, 5) & ~PPC_BITMASK(12, 17),
+		     PPC_PLACE(8, 0, 6));
 
 	/*
 	 *  0     adc_fsm_enable    = 1
@@ -1504,23 +1504,23 @@ static void pm_pss_init(uint8_t chip)
 	 *
 	 * Truncating last value to 4 bits gives 0.
 	 */
-	scom_and_or(PU_SPIPSS_ADC_CTRL_REG0 + 1, ~PPC_BITMASK(0, 17),
-		    PPC_BIT(0) | PPC_PLACE(10, 4, 10) | PPC_PLACE(0, 14, 4));
+	rscom_and_or(chip, PU_SPIPSS_ADC_CTRL_REG0 + 1, ~PPC_BITMASK(0, 17),
+		     PPC_BIT(0) | PPC_PLACE(10, 4, 10) | PPC_PLACE(0, 14, 4));
 
 	/*
 	 * 0-16  inter frame delay
 	 */
-	scom_and(PU_SPIPSS_ADC_CTRL_REG0 + 2, ~PPC_BITMASK(0, 16));
+	rscom_and(chip, PU_SPIPSS_ADC_CTRL_REG0 + 2, ~PPC_BITMASK(0, 16));
 
-	write_scom(PU_SPIPSS_ADC_WDATA_REG, 0);
+	write_rscom(chip, PU_SPIPSS_ADC_WDATA_REG, 0);
 
 	/*
 	 *  0-5   frame size
 	 * 12-17  in delay
 	 */
-	scom_and_or(PU_SPIPSS_P2S_CTRL_REG0,
-		    ~PPC_BITMASK(0, 5) & ~PPC_BITMASK(12, 17),
-		    PPC_PLACE(8, 0, 6));
+	rscom_and_or(chip, PU_SPIPSS_P2S_CTRL_REG0,
+		     ~PPC_BITMASK(0, 5) & ~PPC_BITMASK(12, 17),
+		     PPC_PLACE(8, 0, 6));
 
 	/*
 	 *  0     p2s_fsm_enable    = 1
@@ -1530,23 +1530,23 @@ static void pm_pss_init(uint8_t chip)
 	 *  4-13  p2s_clock_divider = set to 10Mhz
 	 * 17     p2s_nr_of_frames  = 1 (for auto 2 mode)
 	 */
-	scom_and_or(PU_SPIPSS_P2S_CTRL_REG0 + 1,
-		    ~(PPC_BITMASK(0, 13) | PPC_BIT(17)),
-		    PPC_BIT(0) | PPC_PLACE(10, 4, 10) | PPC_BIT(17));
+	rscom_and_or(chip, PU_SPIPSS_P2S_CTRL_REG0 + 1,
+		     ~(PPC_BITMASK(0, 13) | PPC_BIT(17)),
+		     PPC_BIT(0) | PPC_PLACE(10, 4, 10) | PPC_BIT(17));
 
 	/*
 	 * 0-16  inter frame delay
 	 */
-	scom_and(PU_SPIPSS_P2S_CTRL_REG0 + 2, ~PPC_BITMASK(0, 16));
+	rscom_and(chip, PU_SPIPSS_P2S_CTRL_REG0 + 2, ~PPC_BITMASK(0, 16));
 
-	write_scom(PU_SPIPSS_P2S_WDATA_REG, 0);
+	write_rscom(chip, PU_SPIPSS_P2S_WDATA_REG, 0);
 
 	/*
 	 * 0-31  100ns value
 	 */
-	scom_and_or(PU_SPIPSS_100NS_REG,
-		    PPC_BITMASK(0, 31),
-		    PPC_PLACE(powerbus_cfg(chip)->fabric_freq / 40, 0, 32));
+	rscom_and_or(chip, PU_SPIPSS_100NS_REG,
+		     PPC_BITMASK(0, 31),
+		     PPC_PLACE(powerbus_cfg(chip)->fabric_freq / 40, 0, 32));
 }
 
 /* Initializes power-management and starts OCC */
@@ -1554,23 +1554,23 @@ static void start_pm_complex(uint8_t chip, struct homer_st *homer, uint64_t core
 {
 	enum { STOP_RECOVERY_TRIGGER_ENABLE = 29 };
 
-	pm_corequad_init(cores);
+	pm_corequad_init(chip, cores);
 	pm_pss_init(chip);
-	pm_occ_fir_init();
-	pm_pba_fir_init();
-	stop_gpe_init(homer);
+	pm_occ_fir_init(chip);
+	pm_pba_fir_init(chip);
+	stop_gpe_init(chip, homer);
 	pm_pstate_gpe_init(chip, homer, cores);
 
-	check_proc_config(homer);
-	clear_occ_special_wakeups(cores);
-	special_occ_wakeup_disable(cores);
-	occ_start_from_mem();
+	check_proc_config(chip, homer);
+	clear_occ_special_wakeups(chip, cores);
+	special_occ_wakeup_disable(chip, cores);
+	occ_start_from_mem(chip);
 
-	write_scom(PU_OCB_OCI_OCCFLG2_CLEAR, PPC_BIT(STOP_RECOVERY_TRIGGER_ENABLE));
+	write_rscom(chip, PU_OCB_OCI_OCCFLG2_CLEAR, PPC_BIT(STOP_RECOVERY_TRIGGER_ENABLE));
 }
 
 /* Wait for OCC to reach communications checkpoint */
-static void wait_for_occ_checkpoint(void)
+static void wait_for_occ_checkpoint(uint8_t chip)
 {
 	enum {
 		/* Wait up to 15 seconds for OCC to be ready (150 * 100ms = 15s) */
@@ -1593,7 +1593,7 @@ static void wait_for_occ_checkpoint(void)
 		wait_ms(MS_BETWEEN_READ, false);
 
 		/* Read SRAM response buffer to check for OCC checkpoint */
-		readOCCSRAM(OCC_RSP_SRAM_ADDR, (uint64_t *)response, sizeof(response));
+		readOCCSRAM(chip, OCC_RSP_SRAM_ADDR, (uint64_t *)response, sizeof(response));
 
 		/* Pull status from response (byte 2) */
 		status = response[2];
@@ -1746,7 +1746,7 @@ static bool parse_occ_response(struct homer_st *homer, uint8_t occ_cmd,
 	return true;
 }
 
-static bool write_occ_cmd(struct homer_st *homer, uint8_t occ_cmd,
+static bool write_occ_cmd(uint8_t chip, struct homer_st *homer, uint8_t occ_cmd,
 			  const uint8_t *data, uint16_t data_len,
 			  uint8_t *response, uint32_t *response_len)
 {
@@ -1762,7 +1762,7 @@ static bool write_occ_cmd(struct homer_st *homer, uint8_t occ_cmd,
 
 	build_occ_cmd(homer, occ_cmd, cmd_seq_num, data, data_len);
 	/* Sender: HTMGT; command: Command Write Attention */
-	write_occ_command(0x1001000000000000);
+	write_occ_command(chip, 0x1001000000000000);
 
 	/* Wait for OCC to process command and send response (timeout is the
 	 * same for all commands) */
@@ -1792,7 +1792,7 @@ static bool write_occ_cmd(struct homer_st *homer, uint8_t occ_cmd,
 	return true;
 }
 
-static void send_occ_cmd(struct homer_st *homer, uint8_t occ_cmd,
+static void send_occ_cmd(uint8_t chip, struct homer_st *homer, uint8_t occ_cmd,
 			 const uint8_t *data, uint16_t data_len,
 			 uint8_t *response, uint32_t *response_len)
 {
@@ -1801,7 +1801,7 @@ static void send_occ_cmd(struct homer_st *homer, uint8_t occ_cmd,
 	uint8_t i = 0;
 
 	for (i = 0; i < MAX_TRIES; ++i) {
-		if (write_occ_cmd(homer, occ_cmd, data, data_len, response, response_len))
+		if (write_occ_cmd(chip, homer, occ_cmd, data, data_len, response, response_len))
 			break;
 
 		if (i < MAX_TRIES - 1)
@@ -1813,7 +1813,7 @@ static void send_occ_cmd(struct homer_st *homer, uint8_t occ_cmd,
 }
 
 /* Reports OCC error to the user and clears it on OCC's side */
-static void handle_occ_error(struct homer_st *homer,
+static void handle_occ_error(uint8_t chip, struct homer_st *homer,
 			     const struct occ_poll_response *response)
 {
 	static uint8_t error_log_buf[4096];
@@ -1834,19 +1834,19 @@ static void handle_occ_error(struct homer_st *homer,
 		error_length = sizeof(error_log_buf);
 	}
 
-	readOCCSRAM(response->error_address, (uint64_t *)error_log_buf, error_length);
+	readOCCSRAM(chip, response->error_address, (uint64_t *)error_log_buf, error_length);
 
 	printk(BIOS_WARNING, "OCC error log:\n");
 	hexdump(error_log_buf, error_length);
 
 	/* Confirm to OCC that we've read the log */
-	send_occ_cmd(homer, OCC_CMD_CLEAR_ERROR_LOG,
+	send_occ_cmd(chip, homer, OCC_CMD_CLEAR_ERROR_LOG,
 		     clear_log_data, sizeof(clear_log_data),
 		     NULL, &response_len);
 }
 
-static void poll_occ(struct homer_st *homer, bool flush_all_errors,
-		     struct occ_poll_response *response)
+static void poll_occ(uint8_t chip, struct homer_st *homer,
+		     bool flush_all_errors, struct occ_poll_response *response)
 {
 	enum { OCC_POLL_DATA_MIN_SIZE = 40 };
 
@@ -1855,7 +1855,7 @@ static void poll_occ(struct homer_st *homer, bool flush_all_errors,
 		const uint8_t poll_data[1] = { 0x20 /*version*/ };
 		uint32_t response_len = sizeof(*response);
 
-		send_occ_cmd(homer, OCC_CMD_POLL, poll_data, sizeof(poll_data),
+		send_occ_cmd(chip, homer, OCC_CMD_POLL, poll_data, sizeof(poll_data),
 			     (uint8_t *)response, &response_len);
 
 		if (response_len < OCC_POLL_DATA_MIN_SIZE)
@@ -1867,7 +1867,7 @@ static void poll_occ(struct homer_st *homer, bool flush_all_errors,
 		if (response->error_id == 0)
 			break;
 
-		handle_occ_error(homer, response);
+		handle_occ_error(chip, homer, response);
 
 		--max_more_errors;
 		if (max_more_errors == 0) {
@@ -1878,7 +1878,7 @@ static void poll_occ(struct homer_st *homer, bool flush_all_errors,
 	}
 }
 
-static void wait_for_occ_status(struct homer_st *homer, uint8_t status_bit)
+static void wait_for_occ_status(uint8_t chip, struct homer_st *homer, uint8_t status_bit)
 {
 	enum {
 		MAX_POLLS = 40,
@@ -1889,7 +1889,7 @@ static void wait_for_occ_status(struct homer_st *homer, uint8_t status_bit)
 	struct occ_poll_response poll_response;
 
 	for (num_polls = 0; num_polls < MAX_POLLS; ++num_polls) {
-		poll_occ(homer, /*flush_all_errors=*/false, &poll_response);
+		poll_occ(chip, homer, /*flush_all_errors=*/false, &poll_response);
 		if (poll_response.status & status_bit)
 			break;
 
@@ -1905,7 +1905,7 @@ static void wait_for_occ_status(struct homer_st *homer, uint8_t status_bit)
 		die("Failed to wait until OCC has reached state 0x%02x\n", status_bit);
 }
 
-static void set_occ_state(struct homer_st *homer, uint8_t state)
+static void set_occ_state(uint8_t chip, struct homer_st *homer, uint8_t state)
 {
 	struct occ_poll_response poll_response;
 
@@ -1914,13 +1914,13 @@ static void set_occ_state(struct homer_st *homer, uint8_t state)
 	uint32_t response_len = 0;
 
 	/* Send poll cmd to confirm comm has been established and flush old errors */
-	poll_occ(homer, /*flush_all_errors=*/true, &poll_response);
+	poll_occ(chip, homer, /*flush_all_errors=*/true, &poll_response);
 
 	/* Try to switch to a new state */
-	send_occ_cmd(homer, OCC_CMD_SET_STATE, data, sizeof(data), NULL, &response_len);
+	send_occ_cmd(chip, homer, OCC_CMD_SET_STATE, data, sizeof(data), NULL, &response_len);
 
 	/* Send poll to query state of all OCC and flush any errors */
-	poll_occ(homer, /*flush_all_errors=*/true, &poll_response);
+	poll_occ(chip, homer, /*flush_all_errors=*/true, &poll_response);
 
 	if (poll_response.state != state)
 		die("State of OCC is 0x%02x instead of 0x%02x.\n",
@@ -2384,7 +2384,7 @@ static void get_gpu_msg_data(struct homer_st *homer, uint8_t *data, uint16_t *si
 	*size = index;
 }
 
-static void send_occ_config_data(struct homer_st *homer)
+static void send_occ_config_data(uint8_t chip, struct homer_st *homer)
 {
 	/*
 	 * Order in which these are sent is important!
@@ -2417,49 +2417,57 @@ static void send_occ_config_data(struct homer_st *homer)
 		if (data_len > sizeof(data))
 			die("Buffer for OCC data is too small!\n");
 
-		send_occ_cmd(homer, OCC_CMD_SETUP_CFG_DATA, data, data_len, NULL, &response_len);
-		poll_occ(homer, /*flush_all_errors=*/false, &poll_response);
+		send_occ_cmd(chip, homer, OCC_CMD_SETUP_CFG_DATA, data, data_len,
+			     NULL, &response_len);
+		poll_occ(chip, homer, /*flush_all_errors=*/false, &poll_response);
 	}
 }
 
-static void send_occ_user_power_cap(struct homer_st *homer)
+static void send_occ_user_power_cap(uint8_t chip, struct homer_st *homer)
 {
 	/* No power limit */
 	const uint8_t data[2] = { 0x00, 0x00 };
 	uint32_t response_len = 0;
-	send_occ_cmd(homer, OCC_CMD_SET_POWER_CAP, data, sizeof(data), NULL, &response_len);
+	send_occ_cmd(chip, homer, OCC_CMD_SET_POWER_CAP, data, sizeof(data),
+		     NULL, &response_len);
 }
 
-static void set_occ_active_state(struct homer_st *homer)
+static void set_occ_active_state(uint8_t chip, struct homer_st *homer)
 {
 	enum {
 		OCC_STATUS_ACTIVE_READY = 0x01,
 		OCC_STATE_ACTIVE = 0x03,
 	};
 
-	wait_for_occ_status(homer, OCC_STATUS_ACTIVE_READY);
-	set_occ_state(homer, OCC_STATE_ACTIVE);
+	wait_for_occ_status(chip, homer, OCC_STATUS_ACTIVE_READY);
+	set_occ_state(chip, homer, OCC_STATE_ACTIVE);
 }
 
 /* Moves OCC to active state */
-static void activate_occ(struct homer_st *homer)
+static void activate_occ(uint8_t chip, struct homer_st *homer, bool is_master)
 {
+	/* TODO: Hostboot performs each step below for every OCC before moving
+	 *       to the next step (looks like performing it for master OCC
+	 *       first), so might need to loop over every OCC in inside each
+	 *       function below. All this after starting PM complex for every
+	 *       chip outside of this function. */
+
 	struct occ_poll_response poll_response;
 
 	/* Make sure OCCs are ready for communication */
-	wait_for_occ_checkpoint();
+	wait_for_occ_checkpoint(chip);
 
 	/* Send initial poll to all OCCs to establish communication */
-	poll_occ(homer, /*flush_all_errors=*/false, &poll_response);
+	poll_occ(chip, homer, /*flush_all_errors=*/false, &poll_response);
 
 	/* Send OCC's config data */
-	send_occ_config_data(homer);
+	send_occ_config_data(chip, homer);
 
 	/* Set the User PCAP */
-	send_occ_user_power_cap(homer);
+	send_occ_user_power_cap(chip, homer);
 
 	/* Switch for OCC to active state */
-	set_occ_active_state(homer);
+	set_occ_active_state(chip, homer);
 
 	/* Hostboot sets active sensors for all OCCs here, so BMC can start
 	 * communication with OCCs. */
@@ -2474,7 +2482,8 @@ static void istep_21_1(uint8_t chip, struct homer_st *homer, uint64_t cores)
 	printk(BIOS_ERR, "Done starting PM complex\n");
 
 	printk(BIOS_ERR, "Activating OCC...\n");
-	activate_occ(homer);
+	/* Note: only OCCs of chips connected to APSS can be masters */
+	activate_occ(chip, homer, /*is_master=*/(chip == 0));
 	printk(BIOS_ERR, "Done activating OCC\n");
 }
 
@@ -3290,15 +3299,15 @@ static void istep_15_3(uint8_t chip, uint64_t cores)
 		if (!IS_EC_FUNCTIONAL(i, cores))
 			continue;
 
-		if ((read_scom_for_chiplet(chiplet, 0xF0001) & group_mask) == group_mask)
-			scom_and_or_for_chiplet(chiplet, 0xF0001,
-			                        ~(group_mask | PPC_BITMASK(16,23)),
-			                        PPC_BITMASK(19,21));
+		if ((read_rscom_for_chiplet(chip, chiplet, 0xF0001) & group_mask) == group_mask)
+			rscom_and_or_for_chiplet(chip, chiplet, 0xF0001,
+			                         ~(group_mask | PPC_BITMASK(16,23)),
+			                         PPC_BITMASK(19,21));
 
-		if ((read_scom_for_chiplet(chiplet, 0xF0002) & group_mask) == group_mask)
-			scom_and_or_for_chiplet(chiplet, 0xF0002,
-			                        ~(group_mask | PPC_BITMASK(16,23)),
-			                        PPC_BIT(5) | PPC_BITMASK(19,21));
+		if ((read_rscom_for_chiplet(chip, chiplet, 0xF0002) & group_mask) == group_mask)
+			rscom_and_or_for_chiplet(chip, chiplet, 0xF0002,
+			                         ~(group_mask | PPC_BITMASK(16,23)),
+			                         PPC_BIT(5) | PPC_BITMASK(19,21));
 	}
 
 	for (int i = 0; i < MAX_QUADS_PER_CHIP; i++) {

--- a/src/soc/ibm/power9/homer.c
+++ b/src/soc/ibm/power9/homer.c
@@ -3366,6 +3366,15 @@ static void istep_15_3(uint8_t chip, uint64_t cores)
 			qcsr |= PPC_BIT(i);
 	}
 	write_rscom(chip, 0x0006C094, qcsr);
+
+	if (chip != 0) {
+		/*
+		 * PU_OCB_OCI_QSSR_SCOM2 (OR)
+		 * Start no CMEs on slave CPUs (set bit implies stop state).
+		 */
+		write_rscom(chip, 0x0006C09A, PPC_BITMASK(0, 11) | /* CMEs */
+					      PPC_BITMASK(14, 19)  /* EQs */);
+	}
 }
 
 /*

--- a/src/soc/ibm/power9/homer.c
+++ b/src/soc/ibm/power9/homer.c
@@ -1580,9 +1580,9 @@ static void start_pm_complex(uint8_t chip, struct homer_st *homer, uint64_t core
 static void wait_for_occ_checkpoint(uint8_t chip)
 {
 	enum {
-		/* Wait up to 15 seconds for OCC to be ready (150 * 100ms = 15s) */
-		MS_BETWEEN_READ  = 100,
-		READ_RETRY_LIMIT = 150,
+		/* Wait up to 15 seconds for OCC to be ready (1500 * 10ms = 15s) */
+		US_BETWEEN_READ  = 10000,
+		READ_RETRY_LIMIT = 1500,
 
 		OCC_COMM_INIT_COMPLETE = 0x0EFF,
 		OCC_INIT_FAILURE       = 0xE000,
@@ -1590,14 +1590,14 @@ static void wait_for_occ_checkpoint(uint8_t chip)
 		OCC_RSP_SRAM_ADDR = 0xFFFBF000,
 	};
 
-	uint8_t retry_count = 0;
+	int retry_count = 0;
 
 	while (retry_count++ < READ_RETRY_LIMIT) {
 		uint8_t response[8] = { 0x0 };
 		uint8_t status;
 		uint16_t checkpoint;
 
-		wait_ms(MS_BETWEEN_READ, false);
+		udelay(US_BETWEEN_READ);
 
 		/* Read SRAM response buffer to check for OCC checkpoint */
 		readOCCSRAM(chip, OCC_RSP_SRAM_ADDR, (uint64_t *)response, sizeof(response));
@@ -1657,15 +1657,17 @@ static void wait_for_occ_response(struct homer_st *homer, uint32_t timeout_sec,
 				  uint8_t seq_num)
 {
 	enum {
-		OCC_RSP_SAMPLE_TIME_MS = 100,
+		OCC_RSP_SAMPLE_TIME_US = 10,
 		OCC_COMMAND_IN_PROGRESS = 0xFF,
 	};
 
 	const uint8_t *rsp_buf = &homer->occ_host_area[OCC_RSP_ADDR];
 
-	int32_t timeout_ms = (timeout_sec == 0 ? OCC_RSP_SAMPLE_TIME_MS : timeout_sec * 1000);
+	long timeout_us = timeout_sec * USECS_PER_SEC;
+	if (timeout_sec == 0)
+		timeout_us = OCC_RSP_SAMPLE_TIME_US;
 
-	while (timeout_ms >= 0) {
+	while (timeout_us >= 0) {
 		/*
 		 * 1. When OCC receives the command, it will set the status to
 		 *    COMMAND_IN_PROGRESS.
@@ -1691,14 +1693,14 @@ static void wait_for_occ_response(struct homer_st *homer, uint32_t timeout_sec,
 			break;
 		}
 
-		if (timeout_ms > 0) {
+		if (timeout_us > 0) {
 			/* Delay before the next check */
-			int32_t sleep_ms = OCC_RSP_SAMPLE_TIME_MS;
-			if (timeout_ms < sleep_ms)
-				sleep_ms = timeout_ms;
+			long sleep_us = OCC_RSP_SAMPLE_TIME_US;
+			if (timeout_us < sleep_us)
+				sleep_us = timeout_us;
 
-			wait_ms(sleep_ms, false);
-			timeout_ms -= sleep_ms;
+			udelay(sleep_us);
+			timeout_us -= sleep_us;
 		} else {
 			/* Time expired */
 			die("Timed out while waiting for OCC response\n");
@@ -1888,8 +1890,8 @@ static void poll_occ(uint8_t chip, struct homer_st *homer,
 static void wait_for_occ_status(uint8_t chip, struct homer_st *homer, uint8_t status_bit)
 {
 	enum {
-		MAX_POLLS = 40,
-		DELAY_BETWEEN_POLLS_MS = 250,
+		MAX_POLLS = 200,
+		DELAY_BETWEEN_POLLS_US = 50000,
 	};
 
 	uint8_t num_polls = 0;
@@ -1905,7 +1907,7 @@ static void wait_for_occ_status(uint8_t chip, struct homer_st *homer, uint8_t st
 			    poll_response.requested_cfg);
 
 		if (num_polls < MAX_POLLS)
-			wait_ms(DELAY_BETWEEN_POLLS_MS, false);
+			udelay(DELAY_BETWEEN_POLLS_US);
 	}
 
 	if (num_polls == MAX_POLLS)

--- a/src/soc/ibm/power9/occ.c
+++ b/src/soc/ibm/power9/occ.c
@@ -39,16 +39,16 @@ enum fir_offset {
 	ACTION1_INCR    = 7
 };
 
-static void pm_ocb_setup(uint32_t ocb_bar)
+static void pm_ocb_setup(uint8_t chip, uint32_t ocb_bar)
 {
-	write_scom(PU_OCB_PIB_OCBCSR0_OR, PPC_BIT(OCB_PIB_OCBCSR0_OCB_STREAM_MODE));
-	write_scom(PU_OCB_PIB_OCBCSR0_CLEAR, PPC_BIT(OCB_PIB_OCBCSR0_OCB_STREAM_TYPE));
-	write_scom(PU_OCB_PIB_OCBAR0, (uint64_t)ocb_bar << 32);
+	write_rscom(chip, PU_OCB_PIB_OCBCSR0_OR, PPC_BIT(OCB_PIB_OCBCSR0_OCB_STREAM_MODE));
+	write_rscom(chip, PU_OCB_PIB_OCBCSR0_CLEAR, PPC_BIT(OCB_PIB_OCBCSR0_OCB_STREAM_TYPE));
+	write_rscom(chip, PU_OCB_PIB_OCBAR0, (uint64_t)ocb_bar << 32);
 }
 
-static void check_ocb_mode(uint64_t OCBCSR_address, uint64_t OCBSHCS_address)
+static void check_ocb_mode(uint8_t chip, uint64_t OCBCSR_address, uint64_t OCBSHCS_address)
 {
-	uint64_t ocb_pib = read_scom(OCBCSR_address);
+	uint64_t ocb_pib = read_rscom(chip, OCBCSR_address);
 
 	/*
 	 * The following check for circular mode is an additional check
@@ -61,7 +61,7 @@ static void check_ocb_mode(uint64_t OCBCSR_address, uint64_t OCBSHCS_address)
 		 * anyway to let the PIB error response return occur. (That is
 		 * what will happen if this checking code were not here.)
 		 */
-		uint64_t stream_push_control = read_scom(OCBSHCS_address);
+		uint64_t stream_push_control = read_rscom(chip, OCBSHCS_address);
 
 		if (stream_push_control & PPC_BIT(OCB_OCI_OCBSHCS0_PUSH_ENABLE)) {
 			uint8_t counter = 0;
@@ -70,7 +70,7 @@ static void check_ocb_mode(uint64_t OCBCSR_address, uint64_t OCBSHCS_address)
 				if (!(stream_push_control & PPC_BIT(OCB_OCI_OCBSHCS0_PUSH_FULL)))
 					break;
 
-				stream_push_control = read_scom(OCBSHCS_address);
+				stream_push_control = read_rscom(chip, OCBSHCS_address);
 			}
 
 			if (counter == 4)
@@ -79,53 +79,54 @@ static void check_ocb_mode(uint64_t OCBCSR_address, uint64_t OCBSHCS_address)
 	}
 }
 
-static void put_ocb_indirect(uint32_t ocb_req_length, uint32_t oci_address,
-			     uint64_t *ocb_buffer)
+static void put_ocb_indirect(uint8_t chip, uint32_t ocb_req_length,
+			     uint32_t oci_address, uint64_t *ocb_buffer)
 {
-	write_scom(PU_OCB_PIB_OCBAR0, (uint64_t)oci_address << 32);
+	write_rscom(chip, PU_OCB_PIB_OCBAR0, (uint64_t)oci_address << 32);
 
-	check_ocb_mode(PU_OCB_PIB_OCBCSR0_RO, PU_OCB_OCI_OCBSHCS0_SCOM);
+	check_ocb_mode(chip, PU_OCB_PIB_OCBCSR0_RO, PU_OCB_OCI_OCBSHCS0_SCOM);
 
 	for (uint32_t index = 0; index < ocb_req_length; index++)
-		write_scom(PU_OCB_PIB_OCBDR0, ocb_buffer[index]);
+		write_rscom(chip, PU_OCB_PIB_OCBDR0, ocb_buffer[index]);
 }
 
-static void get_ocb_indirect(uint32_t ocb_req_length, uint32_t oci_address,
-			     uint64_t *ocb_buffer)
+static void get_ocb_indirect(uint8_t chip, uint32_t ocb_req_length,
+			     uint32_t oci_address, uint64_t *ocb_buffer)
 {
-	write_scom(PU_OCB_PIB_OCBAR0, (uint64_t)oci_address << 32);
+	write_rscom(chip, PU_OCB_PIB_OCBAR0, (uint64_t)oci_address << 32);
 	for (uint32_t loopCount = 0; loopCount < ocb_req_length; loopCount++)
-		ocb_buffer[loopCount] = read_scom(PU_OCB_PIB_OCBDR0);
+		ocb_buffer[loopCount] = read_rscom(chip, PU_OCB_PIB_OCBDR0);
 }
 
-void writeOCCSRAM(uint32_t address, uint64_t * buffer, size_t data_length)
+void writeOCCSRAM(uint8_t chip, uint32_t address, uint64_t *buffer, size_t data_length)
 {
-	pm_ocb_setup(address);
-	put_ocb_indirect(data_length / 8, address, buffer);
+	pm_ocb_setup(chip, address);
+	put_ocb_indirect(chip, data_length / 8, address, buffer);
 }
 
-void readOCCSRAM(uint32_t address, uint64_t * buffer, size_t data_length)
+void readOCCSRAM(uint8_t chip, uint32_t address, uint64_t *buffer, size_t data_length)
 {
-	pm_ocb_setup(address);
-	get_ocb_indirect(data_length / 8, address, buffer);
+	pm_ocb_setup(chip, address);
+	get_ocb_indirect(chip, data_length / 8, address, buffer);
 }
 
-void write_occ_command(uint64_t write_data)
+void write_occ_command(uint8_t chip, uint64_t write_data)
 {
-	check_ocb_mode(PU_OCB_PIB_OCBCSR1_RO, PU_OCB_OCI_OCBSHCS1_SCOM);
-	write_scom(PU_OCB_PIB_OCBDR1, write_data);
+	check_ocb_mode(chip, PU_OCB_PIB_OCBCSR1_RO, PU_OCB_OCI_OCBSHCS1_SCOM);
+	write_rscom(chip, PU_OCB_PIB_OCBDR1, write_data);
 }
 
-void clear_occ_special_wakeups(uint64_t cores)
+void clear_occ_special_wakeups(uint8_t chip, uint64_t cores)
 {
 	for (size_t i = 0; i < MAX_CORES_PER_CHIP; i += 2) {
 		if (!IS_EX_FUNCTIONAL(i, cores))
 			continue;
-		scom_and_for_chiplet(EC00_CHIPLET_ID + i, EX_PPM_SPWKUP_OCC, ~PPC_BIT(0));
+		rscom_and_for_chiplet(chip, EC00_CHIPLET_ID + i, EX_PPM_SPWKUP_OCC,
+				      ~PPC_BIT(0));
 	}
 }
 
-void special_occ_wakeup_disable(uint64_t cores)
+void special_occ_wakeup_disable(uint8_t chip, uint64_t cores)
 {
 	enum { PPM_SPWKUP_FSP = 0x200F010B };
 
@@ -133,14 +134,14 @@ void special_occ_wakeup_disable(uint64_t cores)
 		if (!IS_EC_FUNCTIONAL(i, cores))
 			continue;
 
-		write_scom_for_chiplet(EC00_CHIPLET_ID + i, PPM_SPWKUP_FSP, 0);
+		write_rscom_for_chiplet(chip, EC00_CHIPLET_ID + i, PPM_SPWKUP_FSP, 0);
 		/* This puts an inherent delay in the propagation of the reset transition */
-		(void)read_scom_for_chiplet(EC00_CHIPLET_ID + i, PPM_SPWKUP_FSP);
+		(void)read_rscom_for_chiplet(chip, EC00_CHIPLET_ID + i, PPM_SPWKUP_FSP);
 	}
 }
 
 /* Sets up boot loader in SRAM and returns 32-bit jump instruction to it */
-static uint64_t setup_memory_boot(void)
+static uint64_t setup_memory_boot(uint8_t chip)
 {
 	enum {
 		OCC_BOOT_OFFSET = 0x40,
@@ -164,12 +165,12 @@ static uint64_t setup_memory_boot(void)
 	sram_program[1] |= ppc_bctr();
 
 	/* Write to SRAM */
-	writeOCCSRAM(OCC_SRAM_BOOT_ADDR, sram_program, sizeof(sram_program));
+	writeOCCSRAM(chip, OCC_SRAM_BOOT_ADDR, sram_program, sizeof(sram_program));
 
 	return ((uint64_t)ppc_b(OCC_SRAM_BOOT_ADDR2) << 32);
 }
 
-void occ_start_from_mem(void)
+void occ_start_from_mem(uint8_t chip)
 {
 	enum {
 		OCB_PIB_OCR_CORE_RESET_BIT = 0,
@@ -182,24 +183,24 @@ void occ_start_from_mem(void)
 		PU_OCB_PIB_OCR_OR    = 0x0006D002,
 	};
 
-	write_scom(PU_OCB_PIB_OCBCSR0_OR, PPC_BIT(OCB_PIB_OCBCSR0_OCB_STREAM_MODE));
+	write_rscom(chip, PU_OCB_PIB_OCBCSR0_OR, PPC_BIT(OCB_PIB_OCBCSR0_OCB_STREAM_MODE));
 
 	/*
 	 * Set up Boot Vector Registers in SRAM:
 	 *  - set bv0-2 to all 0's (illegal instructions)
 	 *  - set bv3 to proper branch instruction
 	 */
-	write_scom(PU_SRAM_SRBV0_SCOM, 0);
-	write_scom(PU_SRAM_SRBV0_SCOM + 1, 0);
-	write_scom(PU_SRAM_SRBV0_SCOM + 2, 0);
-	write_scom(PU_SRAM_SRBV0_SCOM + 3, setup_memory_boot());
+	write_rscom(chip, PU_SRAM_SRBV0_SCOM, 0);
+	write_rscom(chip, PU_SRAM_SRBV0_SCOM + 1, 0);
+	write_rscom(chip, PU_SRAM_SRBV0_SCOM + 2, 0);
+	write_rscom(chip, PU_SRAM_SRBV0_SCOM + 3, setup_memory_boot(chip));
 
-	write_scom(PU_JTG_PIB_OJCFG_AND, ~PPC_BIT(JTG_PIB_OJCFG_DBG_HALT_BIT));
-	write_scom(PU_OCB_PIB_OCR_OR, PPC_BIT(OCB_PIB_OCR_CORE_RESET_BIT));
-	write_scom(PU_OCB_PIB_OCR_CLEAR, PPC_BIT(OCB_PIB_OCR_CORE_RESET_BIT));
+	write_rscom(chip, PU_JTG_PIB_OJCFG_AND, ~PPC_BIT(JTG_PIB_OJCFG_DBG_HALT_BIT));
+	write_rscom(chip, PU_OCB_PIB_OCR_OR, PPC_BIT(OCB_PIB_OCR_CORE_RESET_BIT));
+	write_rscom(chip, PU_OCB_PIB_OCR_CLEAR, PPC_BIT(OCB_PIB_OCR_CORE_RESET_BIT));
 }
 
-void pm_occ_fir_init(void)
+void pm_occ_fir_init(uint8_t chip)
 {
 	enum {
 		PERV_TP_OCC_SCOM_OCCLFIR = 0x01010800,
@@ -292,18 +293,18 @@ void pm_occ_fir_init(void)
 		| PPC_BIT(SRAM_WRITE_ERR)          | PPC_BIT(SRT_FSM_ERR)
 		| PPC_BIT(STOP_RCV_NOTIFY_PRD)     | PPC_BIT(C405_ECC_UE);
 
-	uint64_t mask = read_scom(PERV_TP_OCC_SCOM_OCCLFIR + MASK_INCR);
+	uint64_t mask = read_rscom(chip, PERV_TP_OCC_SCOM_OCCLFIR + MASK_INCR);
 	mask &= ~action0_bits;
 	mask &= ~action1_bits;
 
-	write_scom(PERV_TP_OCC_SCOM_OCCLFIR, 0);
-	write_scom(PERV_TP_OCC_SCOM_OCCLFIR + ACTION0_INCR, action0_bits);
-	write_scom(PERV_TP_OCC_SCOM_OCCLFIR + ACTION1_INCR, action1_bits);
-	write_scom(PERV_TP_OCC_SCOM_OCCLFIR + MASK_WOR_INCR, mask);
-	write_scom(PERV_TP_OCC_SCOM_OCCLFIR + MASK_WAND_INCR, mask);
+	write_rscom(chip, PERV_TP_OCC_SCOM_OCCLFIR, 0);
+	write_rscom(chip, PERV_TP_OCC_SCOM_OCCLFIR + ACTION0_INCR, action0_bits);
+	write_rscom(chip, PERV_TP_OCC_SCOM_OCCLFIR + ACTION1_INCR, action1_bits);
+	write_rscom(chip, PERV_TP_OCC_SCOM_OCCLFIR + MASK_WOR_INCR, mask);
+	write_rscom(chip, PERV_TP_OCC_SCOM_OCCLFIR + MASK_WAND_INCR, mask);
 }
 
-void pm_pba_fir_init(void)
+void pm_pba_fir_init(uint8_t chip)
 {
 	enum {
 		PU_PBAFIR = 0x05012840,
@@ -371,9 +372,9 @@ void pm_pba_fir_init(void)
 	mask &= ~action0_bits;
 	mask &= ~action1_bits;
 
-	write_scom(PU_PBAFIR, 0);
-	write_scom(PU_PBAFIR + ACTION0_INCR, action0_bits);
-	write_scom(PU_PBAFIR + ACTION1_INCR, action1_bits);
-	write_scom(PU_PBAFIR + MASK_WOR_INCR, mask);
-	write_scom(PU_PBAFIR + MASK_WAND_INCR, mask);
+	write_rscom(chip, PU_PBAFIR, 0);
+	write_rscom(chip, PU_PBAFIR + ACTION0_INCR, action0_bits);
+	write_rscom(chip, PU_PBAFIR + ACTION1_INCR, action1_bits);
+	write_rscom(chip, PU_PBAFIR + MASK_WOR_INCR, mask);
+	write_rscom(chip, PU_PBAFIR + MASK_WAND_INCR, mask);
 }


### PR DESCRIPTION
Apart from CPU-specific SCOM accesses, this re-organizes 21.1 to start multiple OCCs.