### PR TITLE
ec/clevo/it5570/acpi/ucsi.asl: Disable the UCSI device

### DIFF
--- a/src/ec/clevo/it5570/acpi/ucsi.asl
+++ b/src/ec/clevo/it5570/acpi/ucsi.asl
@@ -6,7 +6,7 @@ Device (UCSI)
 	Name (_CID, EisaId ("PNP0CA0"))
 	Name (_UID, One)
 	Name (_DDN, "USB Type-C")
-	Name (_STA, 0xf)
+	Name (_STA, 0x0)
 
 	/* Shared memory fields are defined in the SSDT */
 	External (\_SB.PCI0.LPCB.EC0.UCSI.VER0, FieldUnitObj)


### PR DESCRIPTION
The UCSI device is not functional at the moment, possibly because of bugs in EC firmware. Disable it for now until we find a solution, so that no errors are displayed in the OS.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>