### PR TITLE
Faster load

### DIFF
--- a/src/soc/ibm/power9/istep_8_4.c
+++ b/src/soc/ibm/power9/istep_8_4.c
@@ -17,13 +17,18 @@ static bool sbe_run_extract_msg_reg(uint8_t chip)
 		/* SBE is in its operational (runtime) state */
 		SBE_STATE_RUNTIME = 0x4,
 
-		SBE_RETRY_TIMEOUT_HW_SEC = 60,
-		SBE_RETRY_NUM_LOOPS = 60,
+		/*
+		 * Much higher frequency of polling buys us about 333ms here.
+		 * Can also wait with second precision at first (4 seconds) as SBE boots in
+		 * 4.7s every time.
+		 */
+		SBE_RETRY_TIMEOUT_HW_MS = 60 * 1000,
+		SBE_RETRY_NUM_LOOPS = 60 * 100, // 100 times per second
 	};
 
 	/* Each sbe gets 60s to respond with the fact that it's booted and at
-	 * runtime (stable state). Sleep time should be 1 second on HW. */
-	uint64_t SBE_WAIT_SLEEP_SEC = (SBE_RETRY_TIMEOUT_HW_SEC / SBE_RETRY_NUM_LOOPS);
+	 * runtime (stable state). */
+	uint64_t SBE_WAIT_SLEEP_MS = (SBE_RETRY_TIMEOUT_HW_MS / SBE_RETRY_NUM_LOOPS);
 
 	/*
 	 * Layout of the register:
@@ -51,11 +56,12 @@ static bool sbe_run_extract_msg_reg(uint8_t chip)
 		if (msg_reg & (1 << 30))
 			break;
 
-		printk(BIOS_EMERG, "SBE for chip #%d is booting...\n", chip);
+		if ((i * SBE_WAIT_SLEEP_MS) % 1000 == 0)
+			printk(BIOS_EMERG, "SBE for chip #%d is booting...\n", chip);
 
 		/* Hostboot resets watchdog before sleeping, we might want to
 		 * do it too or just increase timer after experimenting. */
-		delay(SBE_WAIT_SLEEP_SEC);
+		mdelay(SBE_WAIT_SLEEP_MS);
 	}
 
 	/* We reach this line only if something is wrong with SBE */

--- a/src/soc/ibm/power9/istep_9_2.c
+++ b/src/soc/ibm/power9/istep_9_2.c
@@ -177,7 +177,7 @@ static void config_run_bus_mode(uint8_t chip)
 
 	/* Set EDIP_TX_ZCAL_REQ to start Tx Impedance Calibration */
 	or_scom(chip, P9A_XBUS_TX_IMPCAL_PB, PPC_BIT(49));
-	udelay(20 * 1000); // 20ms
+	mdelay(20);
 
 	time = wait_us(200 * 10, get_scom(chip, P9A_XBUS_TX_IMPCAL_PB) &
 		       (PPC_BIT(EDIP_TX_ZCAL_DONE) | PPC_BIT(EDIP_TX_ZCAL_ERROR)));
@@ -243,8 +243,6 @@ static void rx_dc_calibration_poll(uint8_t chip, int group)
 
 	long time;
 
-	udelay(100 * 1000); // 100ms
-
 	/*
 	 * EDIP_RX_DC_CALIBRATE_DONE
 	 * (when this bit is read as a 1, the dc calibration steps have been completed)
@@ -286,6 +284,10 @@ static void config_bus_mode(void)
 	rx_dc_calibration_start(/*chip=*/1, /*group=*/0);
 	rx_dc_calibration_start(/*chip=*/0, /*group=*/1);
 	rx_dc_calibration_start(/*chip=*/1, /*group=*/1);
+
+	/* HB does this delay inside rx_dc_calibration_poll(), but doing it
+	 * once instead of four times should be enough */
+	mdelay(100);
 
 	/* Then wait for each combination of chip and group */
 	rx_dc_calibration_poll(/*chip=*/0, /*group=*/0);

--- a/src/soc/ibm/power9/istep_9_7.c
+++ b/src/soc/ibm/power9/istep_9_7.c
@@ -30,7 +30,7 @@ static void p9_fab_iovalid_link_validate(uint8_t chip)
 		if (dl_trained)
 			break;
 
-		udelay(1 * 1000); // 1ms
+		mdelay(1);
 	}
 
 	if (i == 100)
@@ -53,10 +53,6 @@ static void p9_fab_iovalid(uint8_t chip)
 	};
 
 	uint64_t fbc_cent_fir_data;
-
-	/* Add delay for DD1.1+ procedure to compensate for lack of lane lock
-	 * polls */
-	udelay(100 * 1000); // 100ms
 
 	p9_fab_iovalid_link_validate(chip);
 
@@ -86,6 +82,15 @@ void istep_9_7(uint8_t chips)
 	report_istep(9,7);
 
 	if (chips != 0x01) {
+		/*
+		 * Add delay for DD1.1+ procedure to compensate for lack of lane
+		 * lock polls.
+		 *
+		 * HB does this inside p9_fab_iovalid(), which doubles the
+		 * delay, which is probably unnecessary.
+		 */
+		mdelay(100);
+
 		p9_fab_iovalid(/*chip=*/0);
 		p9_fab_iovalid(/*chip=*/1);
 	}

--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -378,11 +378,10 @@ void main(void)
 
 	struct pci_info pci_info[MAX_CHIPS] = { 0 };
 
-	timestamp_add_now(TS_START_ROMSTAGE);
-
 	console_init();
 
 	init_timer();
+	timestamp_add_now(TS_START_ROMSTAGE);
 
 	if (ipmi_premem_init(CONFIG_BMC_BT_BASE, 0) != CB_SUCCESS)
 		die("Failed to initialize IPMI\n");


### PR DESCRIPTION
As a side effect of trying to do things concurrently, code was measured and it became evident that it can run faster after small reorganization: polling at higher frequency, starting things in parallel or after removing superfluous delays.

* baseline: 34.84 seconds
* with these changes: 31.24 seconds
* with these changes and OCC changes (part of #94): 27.22 seconds

The slowest part currently  is building MVPD (13 seconds, 9 for building MVPD of the second CPU), reading cached version from PNOR should take just 50 milliseconds.
