### PR TITLE
tuxedo_ibs15 project config: fix platform name and test spec link

### DIFF
--- a/dasharo/project_config.yaml
+++ b/dasharo/project_config.yaml
@@ -2,7 +2,7 @@
 file_version: v0.0.1
 
 dasharo:
-  platform: clevo_ns50mu
+  platform: tuxedo_ibs15
   newsletter:
     url: https://newsletter.3mdeb.com/subscription/7IPf_aUHR
 

--- a/dasharo/project_config.yaml
+++ b/dasharo/project_config.yaml
@@ -34,7 +34,7 @@ platform:
 tests:
   hardware_matrix: https://docs.dasharo.com/variants/clevo_ns50/testing_configuration/
   results: https://docs.google.com/spreadsheets/d/126oG3VLk51sTIz-uVIAOTVPxA0qpH9wQ4P-ue2fJLtI/edit?pli=1#gid=1057842675
-  specification: https://novacustom.gitlab.io/dasharo-compatibility/dasharo-compatibility/ # FIXME
+  specification: https://docs.dasharo.com/unified-test-documentation/overview
 
 asciinema:
   signature_verification: https://asciinema.org/a/475997


### PR DESCRIPTION
`dasharo.platform` has to be the same as the name of the platform in the release tag.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>