### PR TITLE
southbridge/amd/sb700: Add missing PCI bridge initialization and fix SB MMIO init

### DIFF
--- a/src/southbridge/amd/sb700/Makefile.inc
+++ b/src/southbridge/amd/sb700/Makefile.inc
@@ -18,6 +18,7 @@ ramstage-y += acpi.c
 ramstage-y += hda.c
 ramstage-y += ide.c
 ramstage-y += lpc.c
+ramstage-y += pci.c
 ramstage-y += reset.c
 ramstage-y += sata.c
 ramstage-y += sb700.c

--- a/src/southbridge/amd/sb700/bootblock.c
+++ b/src/southbridge/amd/sb700/bootblock.c
@@ -225,7 +225,7 @@ static void sb700_enable_tpm_decoding(void)
 	dev = PCI_DEV(0, 0x14, 3);
 
 	reg8 = pci_read_config8(dev, 0x7c);
-	reg8 |= 0x81;	/* Tpm12_en and decode 0xfed4xxxx*/
+	reg8 |= 1;	/* Tpm12_en */
 	pci_write_config8(dev, 0x7c, reg8);
 }
 

--- a/src/southbridge/amd/sb700/bootblock.c
+++ b/src/southbridge/amd/sb700/bootblock.c
@@ -15,6 +15,9 @@
 
 #define SPI_CONTROL_1			0xc
 
+#define SB_MMIO_CFG_REG 0x9c
+#define SB_MMIO_BASE_ADDRESS 0xfed80000
+
 static void sb7xx_51xx_pci_port80(void)
 {
 	u8 byte;
@@ -105,6 +108,13 @@ static void sb7xx_51xx_lpc_init(void)
 	/* Enable SB I/O decodes*/
 	pci_write_config8(dev, 0x78, 0xFF);
 	//pci_write_config8(dev, 0x79, 0x45);
+
+	/* Enable southbridge MMIO decode */
+	reg32 = pci_read_config32(dev, SB_MMIO_CFG_REG);
+	reg32 &= ~(0xffffff << 8);
+	reg32 |= SB_MMIO_BASE_ADDRESS;
+	reg32 |= 0x1;
+	pci_write_config32(dev, SB_MMIO_CFG_REG, reg32);
 
 	if (CONFIG(SOUTHBRIDGE_AMD_SB700_DISABLE_ISA_DMA)) {
 		/* Disable LPC ISA DMA Capability */

--- a/src/southbridge/amd/sb700/pci.c
+++ b/src/southbridge/amd/sb700/pci.c
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <device/device.h>
+#include <device/pci.h>
+#include <device/pci_ids.h>
+#include <device/pci_ops.h>
+#include "sb700.h"
+
+static void pci_init(struct device *dev)
+{
+	u32 dword;
+	u16 word;
+	u8 byte;
+
+	/*
+	 * RPR 5.1 Enables the PCI-bridge subtractive decode
+	 * This setting is strongly recommended since it supports some legacy
+	 * PCI add-on cards,such as BIOS debug cards
+	 */
+	byte = pci_read_config8(dev, 0x4B);
+	byte |= 1 << 7;
+	pci_write_config8(dev, 0x4B, byte);
+	byte = pci_read_config8(dev, 0x40);
+	byte |= 1 << 5;
+	pci_write_config8(dev, 0x40, byte);
+
+	/*
+	 * RPR5.2 PCI-bridge upstream dual address window
+	 * This setting is applicable if the system memory is more than 4GB,
+	 * and the PCI device can support dual address access
+	 */
+	byte = pci_read_config8(dev, 0x50);
+	byte |= 1 << 0;
+	pci_write_config8(dev, 0x50, byte);
+
+	/* RPR 5.3 PCI bus 64-byte DMA read access */
+	/* Enhance the PCI bus DMA performance */
+	byte = pci_read_config8(dev, 0x4B);
+	byte |= 1 << 4;
+	pci_write_config8(dev, 0x4B, byte);
+
+	/* RPR 5.4 Enables the PCIB writes to be cacheline aligned. */
+	/* The size of the writes will be set in the Cacheline Register */
+	byte = pci_read_config8(dev, 0x40);
+	byte |= 1 << 1;
+	pci_write_config8(dev, 0x40, byte);
+
+	/*
+	 * RPR 5.5 Enables the PCIB to retain ownership of the bus on the
+	 * Primary side and on the Secondary side when GNT# is deasserted
+	 */
+	pci_write_config8(dev, 0x0D, 0x40);
+	pci_write_config8(dev, 0x1B, 0x40);
+
+	/*
+	 * RPR 5.6 Enable the command matching checking function on
+	 * "Memory Read" & "Memory Read Line" commands
+	 */
+	byte = pci_read_config8(dev, 0x4B);
+	byte |= 1 << 6;
+	pci_write_config8(dev, 0x4B, byte);
+
+	/*
+	 * RPR 5.7 When enabled, the PCI arbiter checks for the Bus Idle
+	 * before asserting GNT#
+	 */
+	byte = pci_read_config8(dev, 0x4B);
+	byte |= 1 << 0;
+	pci_write_config8(dev, 0x4B, byte);
+
+	/* RPR 5.8 Adjusts the GNT# de-assertion time */
+	word = pci_read_config16(dev, 0x64);
+	word |= 1 << 12;
+	pci_write_config16(dev, 0x64, word);
+
+	/* RPR 5.9 Fast Back to Back transactions support */
+	byte = pci_read_config8(dev, 0x48);
+	byte |= 1 << 2;
+	/* pci_write_config8(dev, 0x48, byte); */
+
+	/* RPR 5.10 Enable Lock Operation */
+	/* byte = pci_read_config8(dev, 0x48); */
+	byte |= 1 << 3;
+	pci_write_config8(dev, 0x48, byte);
+
+	/* RPR 5.11 Enable additional optional PCI clock */
+	word = pci_read_config16(dev, 0x64);
+	word |= 1 << 8;
+	pci_write_config16(dev, 0x64, word);
+
+	/* RPR 5.12 Enable One-Prefetch-Channel Mode */
+	dword = pci_read_config32(dev, 0x64);
+	dword |= 1 << 20;
+	pci_write_config32(dev, 0x64, dword);
+
+	/* RPR 5.13 Disable PCIB MSI Capability */
+	byte = pci_read_config8(dev, 0x40);
+	byte &= ~(1 << 3);
+	pci_write_config8(dev, 0x40, byte);
+
+	/* rpr5.14 Adjusting CLKRUN# */
+	dword = pci_read_config32(dev, 0x64);
+	dword |= (1 << 15);
+	pci_write_config32(dev, 0x64, dword);
+}
+
+static struct pci_operations lops_pci = {
+	.set_subsystem = 0,
+};
+
+static struct device_operations pci_ops = {
+	.read_resources = pci_bus_read_resources,
+	.set_resources = pci_dev_set_resources,
+	.enable_resources = pci_bus_enable_resources,
+	.init = pci_init,
+	.scan_bus = pci_scan_bridge,
+	.reset_bus = pci_bus_reset,
+	.ops_pci = &lops_pci,
+};
+
+static const struct pci_driver pci_driver __pci_driver = {
+	.ops = &pci_ops,
+	.vendor = PCI_VENDOR_ID_ATI,
+	.device = PCI_DEVICE_ID_ATI_SB700_PCI,
+};

--- a/src/southbridge/amd/sb700/pci.c
+++ b/src/southbridge/amd/sb700/pci.c
@@ -15,7 +15,7 @@ static void pci_init(struct device *dev)
 	/*
 	 * RPR 5.1 Enables the PCI-bridge subtractive decode
 	 * This setting is strongly recommended since it supports some legacy
-	 * PCI add-on cards,such as BIOS debug cards
+	 * PCI add-on cards, such as BIOS debug cards
 	 */
 	byte = pci_read_config8(dev, 0x4B);
 	byte |= 1 << 7;

--- a/src/southbridge/amd/sb700/sm.c
+++ b/src/southbridge/amd/sb700/sm.c
@@ -310,13 +310,6 @@ static void sm_init(struct device *dev)
 
 		byte |= 1 << 3;
 		pci_write_config8(dev, 0x43, byte);
-
-		/* Enable southbridge MMIO decode */
-		dword = pci_read_config32(dev, SB_MMIO_CFG_REG);
-		dword &= ~(0xffffff << 8);
-		dword |= SB_MMIO_BASE_ADDRESS;
-		dword |= 0x1;
-		pci_write_config32(dev, SB_MMIO_CFG_REG, dword);
 	}
 
 	/* 4.11:Programming Cycle Delay for AB and BIF Clock Gating */
@@ -499,16 +492,6 @@ static void sb700_sm_set_resources(struct device *dev)
 	u8 byte;
 
 	pci_dev_set_resources(dev);
-
-	/*
-	 * Enable SB MMIO
-	 *
-	 * Keep this close to pci_dev_set_resources() to re-enable serial console
-	 * as soon as possible.
-	 */
-	byte = pci_read_config8(dev, SB_MMIO_CFG_REG);
-	byte |= 1;
-	pci_write_config8(dev, SB_MMIO_CFG_REG, byte);
 
 	/* Program HPET BAR Address */
 	res = find_resource(dev, HPET_RESOURCE_NUMBER);

--- a/src/southbridge/amd/sb700/smbus.c
+++ b/src/southbridge/amd/sb700/smbus.c
@@ -4,8 +4,14 @@
 #define _SB700_SMBUS_C_
 
 #include <arch/io.h>
+#include <device/i2c_simple.h>
 #include <northbridge/amd/amdfam10/raminit.h>
 #include "smbus.h"
+
+int __weak platform_i2c_transfer(unsigned int bus, struct i2c_msg *msg, int count)
+{
+	return 0;
+}
 
 void alink_ab_indx(u32 reg_space, u32 reg_addr, u32 mask, u32 val)
 {


### PR DESCRIPTION
Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>