### PR TITLE
build.sh: enable UEFI Secure Boot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,7 @@ cp configs/config.msi_ms7d25 .config
 echo "# CONFIG_CONSOLE_SERIAL is not set" >> .config
 echo "CONFIG_USE_ADLS_IOT_FSP=y" >> .config
 echo "CONFIG_TIANOCORE_BOOTSPLASH_FILE=\"bootsplash.bmp\""  >> .config
+echo "CONFIG_TIANOCORE_SECURE_BOOT=y"  >> .config
 sed -i 's/origin\/dasharo/0a1887584408ffc01b42eeca8a967e2408b58519/g' .config
 
 git submodule update --init --checkout


### PR DESCRIPTION
Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>