### PR TITLE
Fixes for single CPU setup

### DIFF
--- a/src/soc/ibm/power9/romstage.c
+++ b/src/soc/ibm/power9/romstage.c
@@ -344,7 +344,8 @@ static void prepare_dimm_data(uint8_t chips)
 	for (chip = 0; chip < MAX_CHIPS; chip++) {
 		int mcs;
 
-		prepare_cpu_dimm_data(chip);
+		if (chips & (1 << chip))
+			prepare_cpu_dimm_data(chip);
 
 		for (mcs = 0; mcs < MCS_PER_PROC; mcs++)
 			have_dimms |= mem_data[chip].mcs[mcs].functional;


### PR DESCRIPTION
Fixes some issues in Dasharo/dasharo-issues#80 (GitHub won't close the issue on merging this PR).

Tested by making `fsi_get_present_chips()` return `0x01`. Potentially, there can be other issues, but Linux boots fine with hard-coded mask after these fixes.