### PR TITLE
ec/clevo/it5570: store keyboard backlight in CMOS

### DIFF
--- a/src/ec/clevo/it5570/acpi/cmos.asl
+++ b/src/ec/clevo/it5570/acpi/cmos.asl
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+OperationRegion (CMS1, SystemIO, 0x72, 0x2)
+Field (CMS1, ByteAcc, NoLock, Preserve)
+{
+	IND1, 8,
+	DAT1, 8,
+}
+
+IndexField (IND1, DAT1, ByteAcc, NoLock, Preserve)
+{
+	KBBR, 8,		// Keyboard Backlight Brightness
+	KBEN, 8,		// Keyboard Backlight State
+	KBCR, 8,		// Keyboard Backlight Color Red
+	KBCG, 8,		// Keyboard Backlight Color Green
+	KBCB, 8,		// Keyboard Backlight Color Blue
+	KBPS, 8,		// Keyboard Backlight Preset
+}

--- a/src/ec/clevo/it5570/acpi/ec.asl
+++ b/src/ec/clevo/it5570/acpi/ec.asl
@@ -30,6 +30,7 @@ Device (EC0)
 	})
 
 	#include "ec_ram.asl"
+	#include "cmos.asl"
 
 	Name (ECOK, Zero)
 	Method (_REG, 2, Serialized)  // _REG: Region Availability
@@ -60,7 +61,7 @@ Device (EC0)
 			// Apply custom fan curve
 			\_SB.PCI0.LPCB.EC0.SFCV ()
 
-			// Set default keyboard mode
+			// Restore keyboard settings
 			KBUP ()
 
 			// EC is now available

--- a/src/ec/clevo/it5570/acpi/rgb_kb.asl
+++ b/src/ec/clevo/it5570/acpi/rgb_kb.asl
@@ -1,12 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-Name (KBEN, 0x01) // Keyboard Backlight Enable
-Name (KBBR, 0xFF) // Keyboard Brightness
-Name (KBCR, 0xFF) // Keyboard Color Red
-Name (KBCG, 0xFF) // Keyboard Color Green
-Name (KBCB, 0xFF) // Keyboard Color Blue
-Name (KBPS, 0x00) // Keyboard Preset
-
 Method (KBTG, 0, NotSerialized) // Keyboard Toggle
 {
 	KBEN ^= 1

--- a/src/mainboard/clevo/tgl-u/cmos.default
+++ b/src/mainboard/clevo/tgl-u/cmos.default
@@ -1,2 +1,8 @@
 boot_option=Fallback
 preserve_smmstore=0
+kbl_brightness=0x3f
+kbl_state=Enable
+kbl_color_r=0xff
+kbl_color_g=0xff
+kbl_color_b=0xff
+kbl_preset=0

--- a/src/mainboard/clevo/tgl-u/cmos.layout
+++ b/src/mainboard/clevo/tgl-u/cmos.layout
@@ -12,6 +12,14 @@ entries
 408	1	h	1	preserve_smmstore
 984	16	h	0	check_sum
 
+# embedded controller settings
+1024	8	h	0	kbl_brightness
+1032	8	e	1	kbl_state
+1040	8	h	0	kbl_color_r
+1048	8	h	0	kbl_color_g
+1056	8	h	0	kbl_color_b
+1064	8	h	0	kbl_preset
+
 enumerations
 
 1	0	Disable


### PR DESCRIPTION
Add persistent keyboard implementation for laptops with RGB keyboards like NS5x.

Store the keyboard settings in CMOS. Add defaults: Enabled, White color, 20% brightness.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>