### PR TITLE
arch/x86/smbios.c: change BIOS vendor to 3mdeb

### DIFF
--- a/src/arch/x86/smbios.c
+++ b/src/arch/x86/smbios.c
@@ -294,7 +294,7 @@ static int smbios_write_type0(unsigned long *current, int handle)
                                                     sizeof(*t), handle);
 	char bversion[100];
 
-	t->vendor = smbios_add_string(t->eos, "3mdeb Embedded Systems Consulting");
+	t->vendor = smbios_add_string(t->eos, "3mdeb");
 	t->bios_release_date = smbios_add_string(t->eos, coreboot_dmi_date);
 
 	snprintf(bversion, sizeof(bversion), "Dasharo (%s) %s",


### PR DESCRIPTION
Change-Id: I5725ffb5ff26f7d651a80dc083ef9a005bba1101
Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>