### PR TITLE
build.sh: bump patchset to a version with serial number and UUID in CBFS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,8 +33,8 @@ extract_microcode
 git reset --hard HEAD
 git clean -df
 
-git fetch https://review.coreboot.org/coreboot refs/changes/22/64422/2 && \
-        git format-patch -48 --stdout FETCH_HEAD | git apply
+git fetch https://review.coreboot.org/coreboot refs/changes/40/64640/1 && \
+        git format-patch -50 --stdout FETCH_HEAD | git apply
 
 cp configs/config.msi_ms7d25 .config
 


### PR DESCRIPTION
Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>