### PR TITLE
Disable ME on Protectli VP4620

### DIFF
--- a/src/soc/intel/common/block/cse/cse.c
+++ b/src/soc/intel/common/block/cse/cse.c
@@ -1135,7 +1135,10 @@ static void cse_set_state(struct device *dev)
 	 * Check if the CMOS value "me_state" exists, if it doesn't, then
 	 * don't do anything.
 	 */
-	const unsigned int cmos_me_state = get_uint_option("me_state", UINT_MAX);
+	/*
+	 * Hard-coded default value as `1` to always disable ME on startup.
+	 */
+	const unsigned int cmos_me_state = get_uint_option("me_state", 1);
 
 	if (cmos_me_state == UINT_MAX)
 		return;


### PR DESCRIPTION
A draft as there might be issues with ME disabled. If not, I guess this PR can be used to make it optional depending on an EFI variable.

Can be reviewed though, in case something was done wrong. Enabling ME wasn't tested yet.