### PR TITLE
mb/clevo/adl-p/cmos.layout: exclude vbnv from checksums

### DIFF
--- a/src/mainboard/clevo/adl-p/cmos.layout
+++ b/src/mainboard/clevo/adl-p/cmos.layout
@@ -14,6 +14,10 @@ entries
 412	4	e	6	debug_level
 416	1	e	2	me_state
 417	3	h	0	me_state_counter
+
+# Vboot non-volatile data
+800	128	r	0	vbnv
+
 984	16	h	0	check_sum
 
 enumerations
@@ -36,4 +40,4 @@ enumerations
 
 checksums
 
-checksum 408 983 984
+checksum 408 799 984


### PR DESCRIPTION
Fixes https://github.com/Dasharo/dasharo-issues/issues/242

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>