### PR TITLE
mb/clevo/adl-p/variants: disable AER for GbE RP

### DIFF
--- a/src/mainboard/clevo/adl-p/variants/ns50pu/overridetree.cb
+++ b/src/mainboard/clevo/adl-p/variants/ns50pu/overridetree.cb
@@ -152,7 +152,7 @@ chip soc/intel/alderlake
 			register "pch_pcie_rp[PCH_RP(8)]" = "{
 				.clk_src = 6,
 				.clk_req = 6,
-				.flags = PCIE_RP_LTR | PCIE_RP_AER,
+				.flags = PCIE_RP_LTR,
 			}"
 			chip soc/intel/common/block/pcie/rtd3
 				register "enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D4)" # GPIO_LAN_EN

--- a/src/mainboard/clevo/adl-p/variants/nv40pz/overridetree.cb
+++ b/src/mainboard/clevo/adl-p/variants/nv40pz/overridetree.cb
@@ -170,7 +170,7 @@ chip soc/intel/alderlake
 			register "pch_pcie_rp[PCH_RP(10)]" = "{
 				.clk_src = 6,
 				.clk_req = 6,
-				.flags = PCIE_RP_LTR | PCIE_RP_AER,
+				.flags = PCIE_RP_LTR,
 			}"
 			chip soc/intel/common/block/pcie/rtd3
 				register "reset_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_F7)" # LAN_PLT_RST#


### PR DESCRIPTION
Fixes Win11 BSODs while an Ethernet cable is connected.

Addresses https://github.com/Dasharo/dasharo-issues/issues/264

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>