### PR TITLE
commonlib/helpers.h: use unsigned literals in definitions

### DIFF
--- a/src/commonlib/bsd/include/commonlib/bsd/helpers.h
+++ b/src/commonlib/bsd/include/commonlib/bsd/helpers.h
@@ -69,13 +69,13 @@
 } while (0)
 
 /* Standard units. */
-#define KiB (1<<10)
-#define MiB (1<<20)
-#define GiB (1<<30)
+#define KiB (1U<<10)
+#define MiB (1U<<20)
+#define GiB (1U<<30)
 
-#define KHz (1000)
-#define MHz (1000 * KHz)
-#define GHz (1000 * MHz)
+#define KHz (1000U)
+#define MHz (1000U * KHz)
+#define GHz (1000U * MHz)
 
 #ifndef offsetof
 #define offsetof(TYPE, MEMBER) __builtin_offsetof(TYPE, MEMBER)


### PR DESCRIPTION
This protects against some of unintentional integer promotions, e.g.:

	uint16_t freq_mhz = 2148;  // or bigger
	uint64_t freq = freq_mhz * MHz;

In this example, MHz used to be treated as int32_t, and because int32_t can represent every value that uin16_t can, multiplication was being performed with both arguments treated as int32_t. During assignment, result of multiplication is promoted to int64_t (because it can represent each value that int32_t can), and finally implicitly converted to uint64_t.

Promotions preserve the value, including the sign, so if result of multiplication is negative, the same negative number (but extended to 64 bits) is converted to unsigned number.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>
Change-Id: Id90af1b769b502d712c11b87c2bdcc7472737050