### PR TITLE
Persistent keyboard backlight

### DIFF
--- a/src/ec/system76/ec/acpi/cmos.asl
+++ b/src/ec/system76/ec/acpi/cmos.asl
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+OperationRegion (CMS1, SystemIO, 0x72, 0x2)
+Field (CMS1, ByteAcc, NoLock, Preserve)
+{
+	IND1, 8,
+	DAT1, 8,
+}
+
+IndexField (IND1, DAT1, ByteAcc, NoLock, Preserve)
+{
+	KBDL, 8,		// Keyboard Backlight Brightness
+	KBDC, 32,		// Keyboard Backlight Color RGB
+}

--- a/src/ec/system76/ec/acpi/ec.asl
+++ b/src/ec/system76/ec/acpi/ec.asl
@@ -239,7 +239,7 @@ Device (\_SB.PCI0.LPCB.EC0)
 			KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x80) {
 			Debug = "EC: Color Keyboard Color Change"
-			Notify (^^^^S76D, 0x84)
+			//Notify (^^^^S76D, 0x84)
 			KBDC = ^^^^S76D.GKBC
 		} Else {
 			Debug = Concatenate("EC: Other: ", ToHexString(Local0))

--- a/src/ec/system76/ec/acpi/ec.asl
+++ b/src/ec/system76/ec/acpi/ec.asl
@@ -240,7 +240,9 @@ Device (\_SB.PCI0.LPCB.EC0)
 		} ElseIf (Local0 == 0x80) {
 			Debug = "EC: Color Keyboard Color Change"
 			//Notify (^^^^S76D, 0x84)
+#if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
 			KBDC = ^^^^S76D.GKBC
+#endif
 		} Else {
 			Debug = Concatenate("EC: Other: ", ToHexString(Local0))
 		}

--- a/src/ec/system76/ec/acpi/ec.asl
+++ b/src/ec/system76/ec/acpi/ec.asl
@@ -30,6 +30,7 @@ Device (\_SB.PCI0.LPCB.EC0)
 	})
 
 	#include "ec_ram.asl"
+	#include "cmos.asl"
 
 	Name (ECOK, Zero)
 	Method (_REG, 2, Serialized)  // _REG: Region Availability
@@ -118,6 +119,7 @@ Device (\_SB.PCI0.LPCB.EC0)
 	Method (_Q0D, 0, NotSerialized) // Keyboard Backlight
 	{
 		Debug = "EC: Keyboard Backlight"
+		KBDL = ^^^^S76D.GKBL
 	}
 
 	Method (_Q0E, 0, NotSerialized) // Volume Down
@@ -222,18 +224,23 @@ Device (\_SB.PCI0.LPCB.EC0)
 		If (Local0 == 0x8A) {
 			Debug = "EC: White Keyboard Backlight"
 			Notify (^^^^S76D, 0x80)
+			KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x9F) {
 			Debug = "EC: Color Keyboard Toggle"
 			Notify (^^^^S76D, 0x81)
+			KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x81) {
 			Debug = "EC: Color Keyboard Down"
 			Notify (^^^^S76D, 0x82)
+			KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x82) {
 			Debug = "EC: Color Keyboard Up"
 			Notify (^^^^S76D, 0x83)
+			KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x80) {
 			Debug = "EC: Color Keyboard Color Change"
 			Notify (^^^^S76D, 0x84)
+			KBDC = ^^^^S76D.GKBC
 		} Else {
 			Debug = Concatenate("EC: Other: ", ToHexString(Local0))
 		}

--- a/src/ec/system76/ec/acpi/s76.asl
+++ b/src/ec/system76/ec/acpi/s76.asl
@@ -68,17 +68,6 @@ Device (S76D) {
 	}
 
 #if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-	// Set KB LED Brightness
-	Method (SKBL, 1, Serialized) {
-		If (^^PCI0.LPCB.EC0.ECOK) {
-			^^PCI0.LPCB.EC0.FDAT = 6
-			^^PCI0.LPCB.EC0.FBUF = Arg0
-			^^PCI0.LPCB.EC0.FBF1 = 0
-			^^PCI0.LPCB.EC0.FBF2 = Arg0
-			^^PCI0.LPCB.EC0.FCMD = 0xCA
-		}
-	}
-
 	// Set Keyboard Color
 	Method (SKBC, 1, Serialized) {
 		If (^^PCI0.LPCB.EC0.ECOK) {
@@ -92,7 +81,23 @@ Device (S76D) {
 			Return (0)
 		}
 	}
-#else // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
+
+	// Get Keyboard Color
+	Method (GKBC, 0, Serialized) {
+		If (^^PCI0.LPCB.EC0.ECOK) {
+			^^PCI0.LPCB.EC0.FDAT = 0x4
+			^^PCI0.LPCB.EC0.FCMD = 0xCA
+			Local0 = ^^PCI0.LPCB.EC0.FBUF |
+					 ^^PCI0.LPCB.EC0.FBF1 << 16 |
+					 ^^PCI0.LPCB.EC0.FBF2 << 8
+
+			Return (Local0)
+		} Else {
+			Return (0)
+		}
+	}
+#endif // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
+
 	// Get KB LED
 	Method (GKBL, 0, Serialized) {
 		Local0 = 0
@@ -113,7 +118,6 @@ Device (S76D) {
 			^^PCI0.LPCB.EC0.FCMD = 0xCA
 		}
 	}
-#endif // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
 
 	// Fan names
 	Method (NFAN, 0, Serialized) {

--- a/src/ec/system76/ec/acpi/s76.asl
+++ b/src/ec/system76/ec/acpi/s76.asl
@@ -17,7 +17,7 @@ Device (S76D) {
 		Debug = "S76D: RSET"
 		SAPL(0)
 #if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-		SKBC(^^PCI0.LPCB.EC0.KBDC)
+		KBSC(^^PCI0.LPCB.EC0.KBDC)
 #endif // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
 		SKBL(^^PCI0.LPCB.EC0.KBDL)
 	}
@@ -68,8 +68,19 @@ Device (S76D) {
 	}
 
 #if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-	// Set Keyboard Color
 	Method (SKBC, 1, Serialized) {
+		/*
+		 * HACK: Dummy method to tell the OS driver that there is RGB backlight
+		 * available. Without this the keyboard is identified as a white backlit
+		 * keyboard, and the backlight levels don't match. We handle RGB
+		 * backlight entirely in firmware and don't want the OS driver to
+		 * interfere.
+		 */
+		 Return (0)
+	}
+
+	// Set Keyboard Color
+	Method (KBSC, 1, Serialized) {
 		If (^^PCI0.LPCB.EC0.ECOK) {
 			^^PCI0.LPCB.EC0.FDAT = 0x3
 			^^PCI0.LPCB.EC0.FBUF = (Arg0 & 0xFF)

--- a/src/ec/system76/ec/acpi/s76.asl
+++ b/src/ec/system76/ec/acpi/s76.asl
@@ -16,10 +16,10 @@ Device (S76D) {
 	Method (RSET, 0, Serialized) {
 		Debug = "S76D: RSET"
 		SAPL(0)
-		SKBL(0)
 #if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-			SKBC(0xFFFFFF)
+		SKBC(^^PCI0.LPCB.EC0.KBDC)
 #endif // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
+		SKBL(^^PCI0.LPCB.EC0.KBDL)
 	}
 
 	Method (INIT, 0, Serialized) {

--- a/src/mainboard/clevo/adl-p/cmos.default
+++ b/src/mainboard/clevo/adl-p/cmos.default
@@ -1,3 +1,5 @@
 boot_option=Fallback
 debug_level=Debug
 me_state=Enable
+kbl_brightness=0xff
+kbl_color=0x00ffffff

--- a/src/mainboard/clevo/adl-p/cmos.layout
+++ b/src/mainboard/clevo/adl-p/cmos.layout
@@ -20,6 +20,10 @@ entries
 
 984	16	h	0	check_sum
 
+# embedded controller settings
+1024	8	h	0	kbl_brightness
+1040	32	h	0	kbl_color
+
 enumerations
 
 2	0	Enable

--- a/src/mainboard/clevo/tgl-u/cmos.default
+++ b/src/mainboard/clevo/tgl-u/cmos.default
@@ -1,3 +1,5 @@
 boot_option=Fallback
 debug_level=Debug
 power_on_after_fail=Disable
+kbl_brightness=0xff
+kbl_color=0x00ffffff

--- a/src/mainboard/clevo/tgl-u/cmos.layout
+++ b/src/mainboard/clevo/tgl-u/cmos.layout
@@ -29,6 +29,10 @@ entries
 
 # -----------------------------------------------------------------
 
+# embedded controller settings
+1024	8	h	0	kbl_brightness
+1040	32	h	0	kbl_color
+
 enumerations
 
 #ID	value	text

--- a/src/soc/intel/common/block/cse/cse.c
+++ b/src/soc/intel/common/block/cse/cse.c
@@ -1099,7 +1099,7 @@ uint8_t cse_get_me_disable_mode(void)
 
 	return var;
 #else
-	return UINT_MAX;
+	return UINT8_MAX;
 #endif
 }
 


### PR DESCRIPTION
Tested on NS50PU. Works, but setting is overriden later in the boot process by the `system76_acpi` driver. Should probably stop relying on it and either use standard ACPI interfaces or have our own OS driver.

Depends on https://github.com/Dasharo/ec/pull/17
