### PR TITLE
Msi ms7d25/sata hp

### DIFF
--- a/src/mainboard/msi/ms7d25/devicetree.cb
+++ b/src/mainboard/msi/ms7d25/devicetree.cb
@@ -71,6 +71,17 @@ chip soc/intel/alderlake
 		[7] = 1,
 	}"
 
+	register "sata_ports_hotplug" = "{
+		[0] = 1,
+		[1] = 1,
+		[2] = 1,
+		[3] = 1,
+		[4] = 1,
+		[5] = 1,
+		[6] = 1,
+		[7] = 1,
+	}"
+
 	# HDMI on port B
 	register "ddi_portB_config" = "1"
 	register "ddi_ports_config" = "{

--- a/src/soc/intel/alderlake/chip.h
+++ b/src/soc/intel/alderlake/chip.h
@@ -304,6 +304,7 @@ struct soc_intel_alderlake_config {
 	uint8_t sata_salp_support;
 	uint8_t sata_ports_enable[8];
 	uint8_t sata_ports_dev_slp[8];
+	uint8_t sata_ports_hotplug[8];
 
 	/*
 	 * Enable(0)/Disable(1) SATA Power Optimizer on PCH side.

--- a/src/soc/intel/alderlake/fsp_params.c
+++ b/src/soc/intel/alderlake/fsp_params.c
@@ -749,6 +749,8 @@ static void fill_fsps_sata_params(FSP_S_CONFIG *s_cfg,
 			sizeof(s_cfg->SataPortsEnable));
 		memcpy(s_cfg->SataPortsDevSlp, config->sata_ports_dev_slp,
 			sizeof(s_cfg->SataPortsDevSlp));
+		memcpy(s_cfg->SataPortsHotPlug, config->sata_ports_hotplug,
+			sizeof(s_cfg->SataPortsHotPlug));
 	}
 
 	/*


### PR DESCRIPTION
Tested on all 6 full-size SATA ports. Enabled HP for the M.2 slots with SATA capability as well, note that you wouldn't want to hotplug M.2 disks directly, but it may be useful if using some sort of adapter to a fullsize SATA port or another electrically hot-plugable connector.

Fixes https://github.com/Dasharo/dasharo-issues/issues/315