### PR TITLE
ns5x_tgl: restore ELAN touchpad support

### DIFF
--- a/src/mainboard/clevo/tgl-u/acpi/touchpad.asl
+++ b/src/mainboard/clevo/tgl-u/acpi/touchpad.asl
@@ -1,3 +1,5 @@
+External (\_SB.PCI0.I2C0.H015, DeviceObj)
+External (\_SB.PCI0.I2C0.H015._STA, IntObj)
 External (\_SB.PCI0.I2C0.H038, DeviceObj)
 External (\_SB.PCI0.I2C0.H038._STA, IntObj)
 
@@ -5,12 +7,21 @@ Scope (PCI0.LPCB.EC0)
 {
 	Method (TPTG, 0, Serialized)
 	{
-		If (\_SB.PCI0.I2C0.H038._STA == Zero) {
-			\_SB.PCI0.I2C0.H038._STA = 0xF
-		} Else {
-			\_SB.PCI0.I2C0.H038._STA = 0x0
+		If (CondRefOf(\_SB.PCI0.I2C0.H015)) {
+			If (\_SB.PCI0.I2C0.H015._STA == Zero) {
+				\_SB.PCI0.I2C0.H015._STA = 0xF
+			} Else {
+				\_SB.PCI0.I2C0.H015._STA = 0x0
+			}
+			Notify (\_SB.PCI0.I2C0.H015, One)
+		} ElseIf (CondRefOf(\_SB.PCI0.I2C0.H038)) {
+			If (\_SB.PCI0.I2C0.H038._STA == Zero) {
+				\_SB.PCI0.I2C0.H038._STA = 0xF
+			} Else {
+				\_SB.PCI0.I2C0.H038._STA = 0x0
+			}
+			Notify (\_SB.PCI0.I2C0.H038, One)
 		}
-		Notify (\_SB.PCI0.I2C0.H038, One)
 	}
 }
 

--- a/src/mainboard/clevo/tgl-u/variants/ns50mu/devicetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/ns50mu/devicetree.cb
@@ -162,10 +162,18 @@ chip soc/intel/tigerlake
 			# Touchpad I2C bus
 			register "SerialIoI2cMode[PchSerialIoIndexI2C0]" = "PchSerialIoPci"
 			chip drivers/i2c/hid
+				register "generic.hid" = ""ELAN0412""
+				register "generic.desc" = ""Elantech Touchpad""
+				register "generic.irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_B3)"
+				register "generic.detect" = "1"
+				register "hid_desc_reg_offset" = "0x01"
+				device i2c 15 on end
+			end
+			chip drivers/i2c/hid
 				register "generic.hid" = ""FTCS1000""
 				register "generic.desc" = ""FocalTech Touchpad""
 				register "generic.irq_gpio" = "ACPI_GPIO_IRQ_LEVEL_LOW(GPP_B3)"
-				register "generic.probed" = "1"
+				register "generic.detect" = "1"
 				register "hid_desc_reg_offset" = "0x01"
 				device i2c 38 on end
 			end


### PR DESCRIPTION
Was mistakenly dropped during a rebase.

Should fix https://github.com/Dasharo/dasharo-issues/issues/313