### PR TITLE
ec/system76/ec/acpi/s76.asl: reenable keyboard on reboot

### DIFF
--- a/src/ec/system76/ec/acpi/s76.asl
+++ b/src/ec/system76/ec/acpi/s76.asl
@@ -20,6 +20,7 @@ Device (S76D) {
 		KBSC(^^PCI0.LPCB.EC0.KBDC)
 #endif // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
 		SKBL(^^PCI0.LPCB.EC0.KBDL)
+		EKBL(1)
 	}
 
 	Method (INIT, 0, Serialized) {


### PR DESCRIPTION
When rebooting, the lid switch state does not change, so the EC will not automatically reenable backlight. Call EKBL during boot to fix this.