### PR TITLE
Protectli vault ehl/dram fix

### DIFF
--- a/payloads/external/iPXE/Makefile
+++ b/payloads/external/iPXE/Makefile
@@ -47,6 +47,7 @@ fetch: $(project_dir)
 checkout: fetch
 	echo "    Checking out $(project_name) revision $(TAG-y)"
 	cd  $(project_dir); \
+		git checkout -- src/config/general.h; \
 		git checkout master; \
 		git branch -D coreboot 2>/dev/null; \
 		git checkout -b coreboot $(TAG-y)

--- a/src/mainboard/protectli/vault_ehl/Kconfig
+++ b/src/mainboard/protectli/vault_ehl/Kconfig
@@ -29,6 +29,12 @@ config MAX_CPUS
 config CBFS_SIZE
 	default 0x900000
 
+config DIMM_MAX
+	default 1
+
+config DIMM_SPD_SIZE
+	default 512
+
 config VBOOT
 	select GBB_FLAG_DISABLE_EC_SOFTWARE_SYNC
 	select GBB_FLAG_DISABLE_FWMP

--- a/src/mainboard/protectli/vault_ehl/romstage.c
+++ b/src/mainboard/protectli/vault_ehl/romstage.c
@@ -28,7 +28,6 @@ void mainboard_memory_init_params(FSPM_UPD *memupd)
 	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 
 	get_spd_smbus(&blk);
-	dump_spd_info(&blk);
 
 	if (blk.spd_array[0] == NULL)
 		die("No memory detected. Insert DIMM module");

--- a/src/soc/intel/elkhartlake/Kconfig
+++ b/src/soc/intel/elkhartlake/Kconfig
@@ -82,7 +82,7 @@ config DCACHE_RAM_SIZE
 
 config DCACHE_BSP_STACK_SIZE
 	hex
-	default 0x30000
+	default 0x30400
 	help
 	  The amount of anticipated stack usage in CAR by bootblock and
 	  other stages. In the case of FSP_USES_CB_STACK default value will be


### PR DESCRIPTION
Adds necessary Kconfig options for DIMMs. Before only half of the SPD was read by coreboot which caused the FSP to fail DIMM change recognition.

Also increase the BSP stack (1KiB was not accounted for CB stack in the 0x30000 being used by FSP), helped with booting debug build with vboot enabled.

Fix checkout of iPXE  when repo is dirty after config modifications via coreboot's Makefile.