### PR TITLE
Clevo/dock video fixes

### DIFF
--- a/src/ec/system76/ec/Kconfig
+++ b/src/ec/system76/ec/Kconfig
@@ -1,4 +1,5 @@
 config EC_SYSTEM76_EC
+	select EC_ACPI
 	bool
 	help
 	  System76 EC

--- a/src/ec/system76/ec/Makefile.inc
+++ b/src/ec/system76/ec/Makefile.inc
@@ -1,6 +1,7 @@
 ifeq ($(CONFIG_EC_SYSTEM76_EC),y)
 
 all-y += system76_ec.c
+all-y += buttons.c
 smm-$(CONFIG_DEBUG_SMI) += system76_ec.c
 
 endif

--- a/src/ec/system76/ec/acpi.h
+++ b/src/ec/system76/ec/acpi.h
@@ -1,0 +1,11 @@
+#ifndef EC_SYSTEM76_EC_ACPI_H
+#define EC_SYSTEM76_EC_ACPI_H
+
+#include <ec/acpi/ec.h>
+
+#define SYSTEM76_EC_REG_LSTE			0x03
+#define SYSTEM76_EC_REG_LSTE_LID_STATE	0x01
+
+int system76_ec_get_lid_state(void);
+
+#endif /* EC_SYSTEM76_EC_ACPI_H */

--- a/src/ec/system76/ec/buttons.c
+++ b/src/ec/system76/ec/buttons.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <ec/acpi/ec.h>
+
+#include "acpi.h"
+
+/**
+ * Return the state of lid switch.
+ *
+ * @return 1 if the lid is open.
+ */
+int system76_ec_get_lid_state(void)
+{
+	return ec_read(SYSTEM76_EC_REG_LSTE) & SYSTEM76_EC_REG_LSTE_LID_STATE;
+}

--- a/src/mainboard/clevo/adl-p/ramstage.c
+++ b/src/mainboard/clevo/adl-p/ramstage.c
@@ -3,6 +3,7 @@
 #include <drivers/efi/efivars.h>
 #include <ec/system76/ec/commands.h>
 #include <ec/acpi/ec.h>
+#include <ec/system76/ec/acpi.h>
 #include <fmap.h>
 #include <lib.h>
 #include <mainboard/gpio.h>
@@ -267,6 +268,8 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 	params->CpuPcieRpPeerToPeerMode[0] = 1;
 	params->CpuPcieRpMaxPayload[0] = 2; // 512B
 	params->CpuPcieRpAcsEnabled[0] = 1;
+
+	params->LidStatus = system76_ec_get_lid_state();
 }
 
 void mainboard_update_soc_chip_config(struct soc_intel_alderlake_config *config)

--- a/src/soc/intel/common/block/tcss/Kconfig
+++ b/src/soc/intel/common/block/tcss/Kconfig
@@ -2,10 +2,16 @@ config SOC_INTEL_COMMON_BLOCK_TCSS
 	def_bool n
 	select FSPS_USE_MULTI_PHASE_INIT
 	help
-	  Sets up USB2/3 port mapping in TCSS MUX and sets MUX to disconnect state
+	  Sets up USB2/3 port mapping in TCSS MUX.
+
+config ENABLE_TCSS_MUX_DISCONNECT
+	def_bool n
+	help
+	  Set TCSS MUX to disconnect state during boot.
 
 config ENABLE_TCSS_DISPLAY_DETECTION
 	bool "Enable detection of displays over USB Type-C ports with TCSS"
+	select ENABLE_TCSS_MUX_DISCONNECT
 	depends on SOC_INTEL_COMMON_BLOCK_TCSS && RUN_FSP_GOP
 	help
 	  Enable displays to be detected over Type-C ports during boot.

--- a/src/soc/intel/common/block/tcss/tcss.c
+++ b/src/soc/intel/common/block/tcss/tcss.c
@@ -422,7 +422,7 @@ void tcss_configure(const struct typec_aux_bias_pads aux_bias_pads[MAX_TYPE_C_PO
 	if (port_map == NULL)
 		return;
 
-	if (!platform_is_resuming()) {
+	if (CONFIG(ENABLE_TCSS_MUX_DISCONNECT) && !platform_is_resuming()) {
 		for (i = 0; i < num_ports; i++)
 			tcss_init_mux(i, &port_map[i]);
 	}


### PR DESCRIPTION
Fixes https://github.com/Dasharo/dasharo-issues/issues/404 .

Enables Type-C and HDMI monitors in firmware if the laptop lid is closed. When the lid is open, firmware is displayed on the internal display only.