### PR TITLE
Novacustom power limits

### DIFF
--- a/src/mainboard/clevo/adl-p/variants/ns50pu/overridetree.cb
+++ b/src/mainboard/clevo/adl-p/variants/ns50pu/overridetree.cb
@@ -1,10 +1,14 @@
 chip soc/intel/alderlake
-	# HACK: Limit PL4 to PL2 to prevent power-off when system is booted on
-	# battery power. This seems to only happen with the i7 units.
+	# Default values at boot, to be adjusted by EC at runtime according
+    # to available wall brick capabilities.
 	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
 		.tdp_pl1_override = 20,
 		.tdp_pl2_override = 56,
-		.tdp_pl4 = 56, // FIXME: Set to 65
+		.tdp_psyspl2 = 90,
+		.tdp_psyspl3 = 92,
+		.tdp_psyspl3_time = 6,
+		.tdp_psyspl3_dutycycle = 4,
+		.tdp_pl4 = 65,
 	}"
 
 	# GPE configuration

--- a/src/mainboard/clevo/adl-p/variants/nv40pz/overridetree.cb
+++ b/src/mainboard/clevo/adl-p/variants/nv40pz/overridetree.cb
@@ -1,8 +1,14 @@
 chip soc/intel/alderlake
+	# Default values at boot, to be adjusted by EC at runtime according
+    # to available wall brick capabilities.
 	register "power_limits_config[ADL_P_282_482_28W_CORE]" = "{
 		.tdp_pl1_override = 28,
 		.tdp_pl2_override = 60,
-		.tdp_pl4 = 90,
+		.tdp_psyspl2 = 90,
+		.tdp_psyspl3 = 92,
+		.tdp_psyspl3_time = 6,
+		.tdp_psyspl3_dutycycle = 4,
+		.tdp_pl4 = 65,
 	}"
 
 	# GPE configuration

--- a/src/mainboard/clevo/tgl-u/variants/ns50mu/devicetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/ns50mu/devicetree.cb
@@ -1,4 +1,21 @@
 chip soc/intel/tigerlake
+# CPU (soc/intel/tigerlake/cpu.c)
+    register "power_limits_config[POWER_LIMITS_U_4_CORE]" = "{
+		.tdp_psyspl2 = 65,
+		.tdp_psyspl3 = 67,
+		.tdp_psyspl3_time = 6,
+		.tdp_psyspl3_dutycycle = 4,
+		.tdp_pl4 = 65,
+	}"
+
+	register "power_limits_config[POWER_LIMITS_U_2_CORE]" = "{
+		.tdp_psyspl2 = 65,
+		.tdp_psyspl3 = 67,
+		.tdp_psyspl3_time = 6,
+		.tdp_psyspl3_dutycycle = 4,
+		.tdp_pl4 = 65,
+	}"
+
 	register "common_soc_config" = "{
 		// Touchpad I2C bus
 		.i2c[0] = {

--- a/src/mainboard/clevo/tgl-u/variants/nv40mz/devicetree.cb
+++ b/src/mainboard/clevo/tgl-u/variants/nv40mz/devicetree.cb
@@ -1,4 +1,21 @@
 chip soc/intel/tigerlake
+# CPU (soc/intel/tigerlake/cpu.c)
+    register "power_limits_config[POWER_LIMITS_U_4_CORE]" = "{
+		.tdp_psyspl2 = 65,
+		.tdp_psyspl3 = 67,
+		.tdp_psyspl3_time = 6,
+		.tdp_psyspl3_dutycycle = 4,
+		.tdp_pl4 = 65,
+	}"
+
+	register "power_limits_config[POWER_LIMITS_U_2_CORE]" = "{
+		.tdp_psyspl2 = 65,
+		.tdp_psyspl3 = 67,
+		.tdp_psyspl3_time = 6,
+		.tdp_psyspl3_dutycycle = 4,
+		.tdp_pl4 = 65,
+	}"
+
 	register "common_soc_config" = "{
 		// Touchpad I2C bus
 		.i2c[0] = {


### PR DESCRIPTION
Set default limits as if the barrel jack AC adapter is used. These limits are adjusted later by EC.