### PR TITLE
src/soc/intel/alderlake/acpi.c: Fix reported C-states on desktop processors

### DIFF
--- a/src/soc/intel/alderlake/acpi.c
+++ b/src/soc/intel/alderlake/acpi.c
@@ -111,7 +111,11 @@ static const acpi_cstate_t cstate_map[NUM_C_STATES] = {
 static int cstate_set_non_s0ix[] = {
 	C_STATE_C1,
 	C_STATE_C6_LONG_LAT,
+#if CONFIG(SOC_INTEL_ALDERLAKE_PCH_S) || CONFIG(SOC_INTEL_RAPTORLAKE_PCH_S)
+	C_STATE_C8
+#else
 	C_STATE_C7S_LONG_LAT
+#endif
 };
 
 static int cstate_set_s0ix[] = {


### PR DESCRIPTION
Desktop processors do not report C7 substate support in CPUID. Use C8 which
is the first supported lower state than C7 state, which is C8. This fixes
the unsupported C-state Firmware Bug in Linux dmesg.