### PR TITLE
S0ix fixes after EC rebase

### DIFF
--- a/src/ec/system76/ec/acpi/ec.asl
+++ b/src/ec/system76/ec/acpi/ec.asl
@@ -9,6 +9,10 @@ Scope (\_SB) {
 	#include "s76.asl"
 }
 
+Scope (\_SB.PCI0.LPCB.RTC) {
+	#include "cmos.asl"
+}
+
 Device (\_SB.PCI0.LPCB.EC0)
 {
 	Name (_HID, EisaId ("PNP0C09") /* Embedded Controller Device */)  // _HID: Hardware ID
@@ -30,7 +34,6 @@ Device (\_SB.PCI0.LPCB.EC0)
 	})
 
 	#include "ec_ram.asl"
-	#include "cmos.asl"
 
 	Name (ECOK, Zero)
 	Method (_REG, 2, Serialized)  // _REG: Region Availability
@@ -122,7 +125,7 @@ Device (\_SB.PCI0.LPCB.EC0)
 	Method (_Q0D, 0, NotSerialized) // Keyboard Backlight
 	{
 		Debug = "EC: Keyboard Backlight"
-		KBDL = ^^^^S76D.GKBL
+		^^RTC.KBDL = ^^^^S76D.GKBL
 	}
 
 	Method (_Q0E, 0, NotSerialized) // Volume Down
@@ -233,24 +236,24 @@ Device (\_SB.PCI0.LPCB.EC0)
 		If (Local0 == 0x8A) {
 			Debug = "EC: White Keyboard Backlight"
 			Notify (^^^^S76D, 0x80)
-			KBDL = ^^^^S76D.GKBL
+			^^RTC.KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x9F) {
 			Debug = "EC: Color Keyboard Toggle"
 			Notify (^^^^S76D, 0x81)
-			KBDL = ^^^^S76D.GKBL
+			^^RTC.KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x81) {
 			Debug = "EC: Color Keyboard Down"
 			Notify (^^^^S76D, 0x82)
-			KBDL = ^^^^S76D.GKBL
+			^^RTC.KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x82) {
 			Debug = "EC: Color Keyboard Up"
 			Notify (^^^^S76D, 0x83)
-			KBDL = ^^^^S76D.GKBL
+			^^RTC.KBDL = ^^^^S76D.GKBL
 		} ElseIf (Local0 == 0x80) {
 			Debug = "EC: Color Keyboard Color Change"
 			//Notify (^^^^S76D, 0x84)
 #if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-			KBDC = ^^^^S76D.GKBC
+			^^RTC.KBDC = ^^^^S76D.GKBC
 #endif
 		} Else {
 			Debug = Concatenate("EC: Other: ", ToHexString(Local0))

--- a/src/ec/system76/ec/acpi/ec.asl
+++ b/src/ec/system76/ec/acpi/ec.asl
@@ -66,7 +66,7 @@ Device (\_SB.PCI0.LPCB.EC0)
 	Name (S3OS, Zero)
 	Method (PTS, 1, Serialized) {
 		Debug = Concatenate("EC: PTS: ", ToHexString(Arg0))
-		If (ECOK && (Arg0 == 3)) {
+		If (ECOK) {
 			// Save ECOS during sleep
 			S3OS = ECOS
 
@@ -80,7 +80,7 @@ Device (\_SB.PCI0.LPCB.EC0)
 
 	Method (WAK, 1, Serialized) {
 		Debug = Concatenate("EC: WAK: ", ToHexString(Arg0))
-		If (ECOK && (Arg0 == 3)) {
+		If (ECOK) {
 			// Restore ECOS after sleep
 			ECOS = S3OS
 

--- a/src/ec/system76/ec/acpi/ec_ram.asl
+++ b/src/ec/system76/ec/acpi/ec_ram.asl
@@ -36,7 +36,6 @@ Field (ERAM, ByteAcc, Lock, Preserve)
 	OEM2, 8,
 	OEM3, 16,
 	OEM4, 8,	// Extra SCI data
-	Offset (0xCD),
 	TMP2, 8,	// GPU temperature
 	DUT1, 8,	// Fan 1 duty
 	DUT2, 8,	// Fan 2 duty

--- a/src/ec/system76/ec/acpi/s76.asl
+++ b/src/ec/system76/ec/acpi/s76.asl
@@ -18,9 +18,9 @@ Device (S76D) {
 		SAPL(0)
 		EKBL(1)
 #if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-		KBSC(^^PCI0.LPCB.EC0.KBDC)
+		KBSC(^^PCI0.LPCB.RTC.KBDC)
 #endif // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-		SKBL(^^PCI0.LPCB.EC0.KBDL)
+		SKBL(^^PCI0.LPCB.RTC.KBDL)
 	}
 
 	Method (INIT, 0, Serialized) {
@@ -133,9 +133,7 @@ Device (S76D) {
 
 	// Enable KB Led
 	Method (EKBL, 1, Serialized) {
-
-		If (^^PCI0.LPCB.EC0.ECOK &&
-			^^PCI0.LPCB.EC0.LSTE) {
+		If (^^PCI0.LPCB.EC0.ECOK && ^^PCI0.LPCB.EC0.LSTE) {
 				^^PCI0.LPCB.EC0.FDAT = 0x2
 				^^PCI0.LPCB.EC0.FBUF = Arg0
 				^^PCI0.LPCB.EC0.FCMD = 0xCA

--- a/src/ec/system76/ec/acpi/s76.asl
+++ b/src/ec/system76/ec/acpi/s76.asl
@@ -20,7 +20,7 @@ Device (S76D) {
 #if CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
 		KBSC(^^PCI0.LPCB.RTC.KBDC)
 #endif // CONFIG(EC_SYSTEM76_EC_COLOR_KEYBOARD)
-		SKBL(^^PCI0.LPCB.RTC.KBDL)
+		SKLV(^^PCI0.LPCB.RTC.KBDL)
 	}
 
 	Method (INIT, 0, Serialized) {
@@ -122,8 +122,8 @@ Device (S76D) {
 		Return (Local0)
 	}
 
-	// Set KB Led
-	Method (SKBL, 1, Serialized) {
+	// Set KB Led value
+	Method (SKLV, 1, Serialized) {
 		If (^^PCI0.LPCB.EC0.ECOK) {
 			^^PCI0.LPCB.EC0.FDAT = Zero
 			^^PCI0.LPCB.EC0.FBUF = Arg0

--- a/src/mainboard/clevo/tgl-u/acpi/sleep.asl
+++ b/src/mainboard/clevo/tgl-u/acpi/sleep.asl
@@ -37,6 +37,8 @@ Method (MWAK, 1, Serialized)
 Method (MS0X, 1, Serialized)
 {
 	If (Arg0 == 1) {
+		/* HACK: Inform EC to apply PMC hack for S0ix issue */
+		\_SB.PCI0.LPCB.EC0.PTS (0)
 		/* S0ix Entry */
 		\_SB.S76D.EKBL (0)
 		PGPM (MISCCFG_GPIO_PM_CONFIG_BITS)


### PR DESCRIPTION
S0ix PMC hack relies on reading ECOS field, so it has to be read no matter which sleep type we are entering