### PR TITLE
mb/clevo/tgl-u: add backlight levels in line with adl-p

### DIFF
--- a/src/mainboard/clevo/tgl-u/acpi/backlight.asl
+++ b/src/mainboard/clevo/tgl-u/acpi/backlight.asl
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <drivers/intel/gma/acpi/gma.asl>
+
+Scope (GFX0)
+{
+	Name (BRIG, Package (22) {
+		40, /* default AC */
+		40, /* default Battery */
+		5,
+		10,
+		15,
+		20,
+		25,
+		30,
+		35,
+		40,
+		45,
+		50,
+		55,
+		60,
+		65,
+		70,
+		75,
+		80,
+		85,
+		90,
+		95,
+		100
+	})
+}

--- a/src/mainboard/clevo/tgl-u/acpi/mainboard.asl
+++ b/src/mainboard/clevo/tgl-u/acpi/mainboard.asl
@@ -9,4 +9,7 @@
 Scope (\_SB) {
 	#include "sleep.asl"
 	#include "touchpad.asl"
+	Scope (PCI0) {
+		#include "backlight.asl"
+	}
 }

--- a/src/mainboard/clevo/tgl-u/dsdt.asl
+++ b/src/mainboard/clevo/tgl-u/dsdt.asl
@@ -20,7 +20,6 @@ DefinitionBlock(
 		#include <soc/intel/common/block/acpi/acpi/northbridge.asl>
 		#include <soc/intel/tigerlake/acpi/southbridge.asl>
 		#include <soc/intel/tigerlake/acpi/tcss.asl>
-		#include <drivers/intel/gma/acpi/default_brightness_levels.asl>
 	}
 
 	Scope (\_SB.PCI0.LPCB)


### PR DESCRIPTION
Add the same linear backlight levels that we use for ADL-P models, in place of coreboot's default exponential levels.