### PR TITLE
payloads/external/iPXE/Makefile: build using $CPUS jobs

### DIFF
--- a/payloads/external/iPXE/Makefile
+++ b/payloads/external/iPXE/Makefile
@@ -30,6 +30,8 @@ else
 IPXE_BUILD_TARGET := bin/$(PXE_ROM_PCI_ID).rom
 endif
 
+PXE_MAKE_OPTS += -j $(CPUS)
+
 all: build
 
 $(project_dir):


### PR DESCRIPTION
Allow using the $CPUS variable to control how many jobs are used for building iPXE. Consideralby speeds up compilation when building coreboot with `CPUS=17 NUM_CPUS=17 make -j17` on an i5-1240P (until now, iPXE took the longest to build of all Dasharo components)