### PR TITLE
Msi ms7d25/sio power config

### DIFF
--- a/src/mainboard/msi/ms7d25/smihandler.c
+++ b/src/mainboard/msi/ms7d25/smihandler.c
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/x86/smm.h>
+#include <device/pnp_ops.h>
+#include <superio/nuvoton/nct6687d/nct6687d.h>
+
+#define POWER_DEV PNP_DEV(0x4e, NCT6687D_SLEEP_PWR)
+#define ACPI_DEV PNP_DEV(0x4e, NCT6687D_ACPI)
+
+#define NUVOTON_ENTRY_KEY 0x87
+#define NUVOTON_EXIT_KEY 0xAA
+
+static void nuvoton_pnp_enter_conf_state(pnp_devfn_t dev)
+{
+	u16 port = dev >> 8;
+	outb(NUVOTON_ENTRY_KEY, port);
+	outb(NUVOTON_ENTRY_KEY, port);
+}
+
+static void nuvoton_pnp_exit_conf_state(pnp_devfn_t dev)
+{
+	u16 port = dev >> 8;
+	outb(NUVOTON_EXIT_KEY, port);
+}
+
+static void disable_ps2_wake(void)
+{
+	uint8_t reg;
+
+	pnp_set_logical_device(ACPI_DEV);
+	reg = pnp_read_config(ACPI_DEV, 0xe4);
+	reg &= ~0xc0; /* Disable keyboard and mouse wake via PSOUT# */
+	reg &= ~0x08; /* Disable keyboard wake with any key */
+	pnp_write_config(ACPI_DEV, 0xe4, reg);
+}
+
+void mainboard_smi_sleep(u8 slp_typ)
+{
+	nuvoton_pnp_enter_conf_state(POWER_DEV);
+	pnp_set_logical_device(POWER_DEV);
+
+	switch (slp_typ) {
+	case 3:
+		pnp_write_config(POWER_DEV, 0xe7, 0x20); /* Keep LED freq at S3-S5 */
+		pnp_write_config(POWER_DEV, 0xe8, 0x05); /* Blink LED at 1Hz */
+		break;
+	case 4:
+		pnp_write_config(POWER_DEV, 0xe7, 0x88); /* Set AUTO_EN */
+		pnp_write_config(POWER_DEV, 0xe8, 0x07); /* LED to low */
+		break;
+	case 5:
+		pnp_write_config(POWER_DEV, 0xe7, 0x88); /* Set AUTO_EN */
+		pnp_write_config(POWER_DEV, 0xe8, 0x07); /* LED to low */
+		disable_ps2_wake();
+		break;
+	}
+
+	nuvoton_pnp_exit_conf_state(POWER_DEV);
+}

--- a/src/mainboard/msi/ms7e06/smihandler.c
+++ b/src/mainboard/msi/ms7e06/smihandler.c
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <cpu/x86/smm.h>
+#include <device/pnp_ops.h>
+#include <superio/nuvoton/nct6687d/nct6687d.h>
+
+#define POWER_DEV PNP_DEV(0x4e, NCT6687D_SLEEP_PWR)
+#define ACPI_DEV PNP_DEV(0x4e, NCT6687D_ACPI)
+
+#define NUVOTON_ENTRY_KEY 0x87
+#define NUVOTON_EXIT_KEY 0xAA
+
+static void nuvoton_pnp_enter_conf_state(pnp_devfn_t dev)
+{
+	u16 port = dev >> 8;
+	outb(NUVOTON_ENTRY_KEY, port);
+	outb(NUVOTON_ENTRY_KEY, port);
+}
+
+static void nuvoton_pnp_exit_conf_state(pnp_devfn_t dev)
+{
+	u16 port = dev >> 8;
+	outb(NUVOTON_EXIT_KEY, port);
+}
+
+static void disable_ps2_wake(void)
+{
+	uint8_t reg;
+
+	pnp_set_logical_device(ACPI_DEV);
+	reg = pnp_read_config(ACPI_DEV, 0xe4);
+	reg &= ~0xc0; /* Disable keyboard and mouse wake via PSOUT# */
+	reg &= ~0x08; /* Disable keyboard wake with any key */
+	pnp_write_config(ACPI_DEV, 0xe4, reg);
+}
+
+void mainboard_smi_sleep(u8 slp_typ)
+{
+	nuvoton_pnp_enter_conf_state(POWER_DEV);
+	pnp_set_logical_device(POWER_DEV);
+
+	switch (slp_typ) {
+	case 3:
+		pnp_write_config(POWER_DEV, 0xe7, 0x20); /* Keep LED freq at S3-S5 */
+		pnp_write_config(POWER_DEV, 0xe8, 0x05); /* Blink LED at 1Hz */
+		break;
+	case 4:
+		pnp_write_config(POWER_DEV, 0xe7, 0x88); /* Set AUTO_EN */
+		pnp_write_config(POWER_DEV, 0xe8, 0x07); /* LED to low */
+		break;
+	case 5:
+		pnp_write_config(POWER_DEV, 0xe7, 0x88); /* Set AUTO_EN */
+		pnp_write_config(POWER_DEV, 0xe8, 0x07); /* LED to low */
+		disable_ps2_wake();
+		break;
+	}
+
+	nuvoton_pnp_exit_conf_state(POWER_DEV);
+}

--- a/src/superio/nuvoton/nct6687d/superio.c
+++ b/src/superio/nuvoton/nct6687d/superio.c
@@ -23,6 +23,76 @@
 #define NCT6687D_ACPI_POWER_PREV_STATE		(2 << NCT6687D_ACPI_POWER_LOSS_CONTROL_SHIFT)
 #define NCT6687D_ACPI_POWER_USER_DEFINED	(3 << NCT6687D_ACPI_POWER_LOSS_CONTROL_SHIFT)
 
+/* 0xe7 register definitions */
+#define NCT6687D_ACPI_ON_PSOUT_MASK		0x10
+#define NCT6687D_ACPI_ON_PSOUT_SHIFT		4
+#define NCT6687D_ACPI_ON_PSOUT_DIS		(0 << NCT6687D_ACPI_ON_PSOUT_SHIFT)
+#define NCT6687D_ACPI_ON_PSOUT_EN		(1 << NCT6687D_ACPI_ON_PSOUT_SHIFT)
+
+static void nct6687d_configure_power_fail_state(struct device *dev)
+{
+	uint8_t reg_eb, reg_e7;
+	uint8_t power_status;
+	/* Set power state after power fail */
+	power_status = dasharo_get_power_on_after_fail();
+
+	pnp_enter_conf_mode(dev);
+	pnp_set_logical_device(dev);
+
+	reg_eb = pnp_read_config(dev, 0xeb);
+	reg_e7 = pnp_read_config(dev, 0xe7);
+	reg_eb &= ~NCT6687D_ACPI_POWER_LOSS_CONTROL_MASK;
+	reg_e7 &= ~NCT6687D_ACPI_ON_PSOUT_MASK;
+
+	if (power_status == MAINBOARD_POWER_ON) {
+		reg_eb |= NCT6687D_ACPI_POWER_ALWAYS_ON;
+		reg_e7 |= NCT6687D_ACPI_ON_PSOUT_EN;
+	} else if (power_status == MAINBOARD_POWER_KEEP) {
+		reg_eb |= NCT6687D_ACPI_POWER_PREV_STATE;
+		reg_e7 |= NCT6687D_ACPI_ON_PSOUT_EN;
+	}
+
+	pnp_write_config(dev, 0xeb, reg_eb);
+	pnp_write_config(dev, 0xe7, reg_e7);
+	pnp_exit_conf_mode(dev);
+
+	printk(BIOS_INFO, "set power %s after power fail\n",
+		power_status ? "on" : "off");
+}
+
+static void nct6687d_configure_ps2_wake(struct device *dev)
+{
+	uint8_t reg;
+	struct device *ps2_dev = dev_find_slot_pnp(dev->path.pnp.port, NCT6687D_KBC);
+
+	if (!ps2_dev || !ps2_dev->enabled)
+		return;
+
+	pnp_enter_conf_mode(dev);
+	pnp_set_logical_device(dev);
+
+	reg = pnp_read_config(dev, 0xe0);
+	reg |= 0x01; /* Any character from the keybaord can wake up the system */
+	reg &= 0xed; /* Clear MSXKEY and MSRKEY to allow either left or right click to wake */
+	pnp_write_config(dev, 0xe0, reg);
+
+	reg = pnp_read_config(dev, 0xe6);
+	reg |= 0x80; /* Set ENMDAT to allow either left or right click to wake */
+	pnp_write_config(dev, 0xe6, reg);
+
+	reg = pnp_read_config(dev, 0xe7);
+	reg &= 0x3f; /* Disable 2nd and 3rd set of wake-up key combinations */
+	reg |= 0x20; /* Enable Win98 dedicated wake up key */
+	pnp_write_config(dev, 0xe7, reg);
+
+	reg = pnp_read_config(dev, 0xe4);
+	reg |= 0xc0; /* Enable keyboard and mouse wake via PSOUT# */
+	reg |= 0x08; /* Enable keyboard wake with any key */
+	pnp_write_config(dev, 0xe4, reg);
+
+	pnp_exit_conf_mode(dev);
+}
+
 static void nct6687d_init(struct device *dev)
 {
 	const struct superio_nuvoton_nct6687d_config *conf;
@@ -32,27 +102,12 @@ static void nct6687d_init(struct device *dev)
 		return;
 
 	switch (dev->path.pnp.device) {
-	/* TODO: Might potentially need code for EC, GPIOs, etc. */
 	case NCT6687D_KBC:
 		pc_keyboard_init(PROBE_AUX_DEVICE);
 		break;
 	case NCT6687D_ACPI:
-		uint8_t byte;
-		uint8_t power_status;
-		/* Set power state after power fail */
-		power_status = dasharo_get_power_on_after_fail();
-		pnp_enter_conf_mode(dev);
-		pnp_set_logical_device(dev);
-		byte = pnp_read_config(dev, 0xeb);
-		byte &= ~NCT6687D_ACPI_POWER_LOSS_CONTROL_MASK;
-		if (power_status == MAINBOARD_POWER_ON)
-			byte |= NCT6687D_ACPI_POWER_ALWAYS_ON;
-		else if (power_status == MAINBOARD_POWER_KEEP)
-			byte |= NCT6687D_ACPI_POWER_PREV_STATE;
-		pnp_write_config(dev, 0xeb, byte);
-		pnp_exit_conf_mode(dev);
-		printk(BIOS_INFO, "set power %s after power fail\n",
-		       power_status ? "on" : "off");
+		nct6687d_configure_power_fail_state(dev);
+		nct6687d_configure_ps2_wake(dev);
 		break;
 	case NCT6687D_EC:
 		conf = dev->chip_info;


### PR DESCRIPTION
Configures blinking LED on S3 sleep, PS/2 KBD and mouse wake from S3/S4. Also added a bit that is enabled by MSI firmware to handle power loss. Maybe this was causing issues reported during validation of the power status after power fail feature (at least it worked for me without any modifications).