### PR TITLE
Nvc tbt fixes

### DIFF
--- a/src/ec/system76/ec/acpi/ec.asl
+++ b/src/ec/system76/ec/acpi/ec.asl
@@ -96,6 +96,20 @@ Device (\_SB.PCI0.LPCB.EC0)
 		}
 	}
 
+	Method (S0IX, 1, Serialized) {
+		Printf ("EC: S0ix hook")
+		If (ECOK) {
+			S0XH = Arg0
+		}
+	}
+
+	Method (EDSX, 1, Serialized) {
+		Printf ("EC: Display hook")
+		If (ECOK) {
+			DSPH = Arg0
+		}
+	}
+
 	Method (_Q0A, 0, NotSerialized) // Touchpad Toggle
 	{
 		Printf ("EC: Touchpad Toggle")

--- a/src/ec/system76/ec/acpi/ec_ram.asl
+++ b/src/ec/system76/ec/acpi/ec_ram.asl
@@ -45,4 +45,7 @@ Field (ERAM, ByteAcc, Lock, Preserve)
 	Offset (0xD9),
 	AIRP, 8,	// Airplane mode LED
 	WINF, 8,	// Enable ACPI brightness controls
+	Offset (0xE0),
+	S0XH, 1,	// S0ix hook
+	DSPH, 1,	// Display hook
 }

--- a/src/soc/intel/alderlake/romstage/fsp_params.c
+++ b/src/soc/intel/alderlake/romstage/fsp_params.c
@@ -4,6 +4,7 @@
 #include <console/console.h>
 #include <cpu/x86/msr.h>
 #include <cpu/intel/cpu_ids.h>
+#include <dasharo/options.h>
 #include <device/device.h>
 #include <drivers/wifi/generic/wifi.h>
 #include <elog.h>
@@ -306,7 +307,7 @@ static void fill_fspm_vtd_params(FSP_M_CONFIG *m_cfg,
 	m_cfg->VtdIgdEnable = m_cfg->InternalGfx;
 	m_cfg->VtdIpuEnable = m_cfg->SaIpuEnable;
 
-	m_cfg->PreBootDmaMask = CONFIG(ENABLE_EARLY_DMA_PROTECTION);
+	m_cfg->PreBootDmaMask = CONFIG(ENABLE_EARLY_DMA_PROTECTION) && dma_protection_enabled();
 
 	if (m_cfg->VtdIgdEnable && m_cfg->VtdBaseAddress[VTD_GFX] == 0) {
 		m_cfg->VtdIgdEnable = 0;

--- a/src/soc/intel/common/block/vtd/vtd.c
+++ b/src/soc/intel/common/block/vtd/vtd.c
@@ -286,8 +286,10 @@ void vtd_enable_dma_protection(void)
 	if (!CONFIG(ENABLE_EARLY_DMA_PROTECTION))
 		return;
 
-	if (!dma_protection_enabled())
+	if (!dma_protection_enabled()) {
+		printk(BIOS_INFO, "VT-d DMA protection disabled by option\n");
 		return;
+	}
 
 	vtd_engine_enable_dma_protection(VTVC0_BASE_ADDRESS);
 	/*

--- a/src/soc/intel/tigerlake/romstage/fsp_params.c
+++ b/src/soc/intel/tigerlake/romstage/fsp_params.c
@@ -4,6 +4,7 @@
 #include <console/console.h>
 #include <cpu/intel/cpu_ids.h>
 #include <cpu/x86/msr.h>
+#include <dasharo/options.h>
 #include <device/device.h>
 #include <fsp/util.h>
 #include <gpio.h>
@@ -184,7 +185,7 @@ static void soc_memory_init_params(FSP_M_CONFIG *m_cfg,
 			m_cfg->VtdBaseAddress[6] = TBT3_BASE_ADDRESS;
 	}
 
-	m_cfg->PreBootDmaMask = CONFIG(ENABLE_EARLY_DMA_PROTECTION);
+	m_cfg->PreBootDmaMask = CONFIG(ENABLE_EARLY_DMA_PROTECTION) && dma_protection_enabled();
 
 	/* Change VmxEnable UPD value according to ENABLE_VMX Kconfig */
 	m_cfg->VmxEnable = CONFIG(ENABLE_VMX);


### PR DESCRIPTION
Hide the TBT DMA devices so Windows stops complaining about missing drivers. Verify that XDomain networking still works under Linux. ATM it's not possible to verify if other USB4 tunneling functionality is working.

Needs https://github.com/Dasharo/ec/pull/52