### PR TITLE
mainboard/protectli/vault_jsl: Fix CRB TPM scope in devicetree

### DIFF
--- a/src/mainboard/protectli/vault_jsl/devicetree.cb
+++ b/src/mainboard/protectli/vault_jsl/devicetree.cb
@@ -167,10 +167,9 @@ chip soc/intel/jasperlake
 		device pci 1f.4 on  end # SMBus
 		device pci 1f.5 on  end # PCH SPI
 		device pci 1f.7 off end # Intel Trace Hub
-	end
 
-	chip drivers/crb
-		device mmio 0xfed40000 on end
+		chip drivers/crb
+			device mmio 0xfed40000 on end
+		end
 	end
-
 end


### PR DESCRIPTION
TPMs in coreboot have to be in PCI domain scope, because the TPM memory is advertised in the ACPI under SB.PCI0 as resource producer. If TPM is not under SB.PCI0 in ACPI, then WIndows will eb unable to claim the TPM memory for TPM ACPI device.