### PR TITLE
vendorcode/dasharo/options.c: use proper Kconfig option

### DIFF
--- a/src/vendorcode/dasharo/options.c
+++ b/src/vendorcode/dasharo/options.c
@@ -9,7 +9,7 @@
 #include <types.h>
 #include <uuid.h>
 
-#if !CONFIG(SOC_AMD_COMMON)
+#if CONFIG(SOC_INTEL_COMMON_BLOCK_CSE)
 #include <intelblocks/cse.h>
 #endif
 
@@ -205,7 +205,7 @@ bool dma_protection_enabled(void)
 	return iommu_var.iommu_enable;
 }
 
-#if !CONFIG(SOC_AMD_COMMON)
+#if CONFIG(SOC_INTEL_COMMON_BLOCK_CSE)
 static void disable_me_hmrfpo(uint8_t *var)
 {
 	int hmrfpo_sts = cse_hmrfpo_get_status();


### PR DESCRIPTION
SOC_AMD_COMMON doesn't make sense, SOC_INTEL_COMMON_BLOCK_CSE is much better for guarding functions that depend on CSE.

Fixes: 8cab580c8619 vendorcode/dasharo/options.c: fix building for AMD