### PR TITLE
mainboard/protectli/vault_ehl: Disable HWP

### DIFF
--- a/src/mainboard/protectli/vault_ehl/mainboard.c
+++ b/src/mainboard/protectli/vault_ehl/mainboard.c
@@ -12,6 +12,14 @@ static void mainboard_final(void *chip_info)
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *silconfig)
 {
+	/*
+	 * HWP is too aggressive in power savings and does not let using full
+	 * bandwidth of Ethernet controllers without additional stressing of
+	 * the CPUs (2Gb/s vs 2.35Gb/s with stressing, measured with iperf3).
+	 * Let the Linux use acpi-cpufreq governor driver instead of
+	 * intel_pstate by disabling HWP.
+	 */
+	silconfig->Hwp = 0;
 }
 
 struct chip_operations mainboard_ops = {


### PR DESCRIPTION
HWP is too aggressive in power savings and does not let using full bandwidth of Ethernet controllers without additional stressing of the CPUs (2Gb/s vs 2.35Gb/s with stressing, measured with iperf3). Let the Linux use acpi-cpufreq governor driver instead of intel_pstate by disabling HWP.