### PR TITLE
security/vboot/Makefile.mk: silence warnings when signing binary

### DIFF
--- a/src/security/vboot/Makefile.mk
+++ b/src/security/vboot/Makefile.mk
@@ -387,7 +387,7 @@ files_added:: $(obj)/coreboot.rom $(FUTILITY) $(CBFSTOOL)
 		--kernelkey "$(CONFIG_VBOOT_KERNEL_KEY)" \
 		--version $(CONFIG_VBOOT_KEYBLOCK_VERSION) \
 		--flags $(CONFIG_VBOOT_KEYBLOCK_PREAMBLE_FLAGS) \
-		$(obj)/coreboot.rom
+		$(obj)/coreboot.rom 2> /dev/null
 	if [ "$(CONFIG_VBOOT_SLOTS_RW_AB)" = 'y' ]; then \
 		printf "    FLASHMAP Layout generated for RO, A and B partition.\n"; \
 	elif [ "$(CONFIG_VBOOT_SLOTS_RW_A)" = 'y' ]; then \


### PR DESCRIPTION
futility always prints a warning when building:

WARNING: prepare_slot: VBLOCK_A keyblock is invalid.

This is the expected state, because at that point vblock hasn't been created yet.

Pipe warnings to /dev/null to prevent worrying users unnecesarily.

Change-Id: I93fd5dafe220bafcf5325ecd4f9f4ee94fc3f81f