### PR TITLE
mainboard/protectli/vault_jsl/devicetree.cb: Disable SATA

### DIFF
--- a/payloads/external/edk2/Makefile
+++ b/payloads/external/edk2/Makefile
@@ -186,7 +186,7 @@ endif
 # IOMMU_ENABLE			= FALSE
 ifeq ($(CONFIG_IOMMU_ENABLE),y)
 BUILD_STR += -D IOMMU_ENABLE=TRUE
-BUILD_STR += --pcd gUefiPayloadPkgTokenSpaceGuid.PcdShowIommuOptions=TRUE
+BUILD_STR += --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions=TRUE
 endif
 # DASHARO_SYSTEM_FEATURES	= FALSE
 ifeq ($(CONFIG_EDK2_DASHARO_SYSTEM_FEATURES),y)

--- a/src/mainboard/protectli/vault_jsl/devicetree.cb
+++ b/src/mainboard/protectli/vault_jsl/devicetree.cb
@@ -121,7 +121,7 @@ chip soc/intel/jasperlake
 		device pci 16.1 off end # HECI 2
 		device pci 16.4 off end # HECI 3
 		device pci 16.5 off end # HECI 4
-		device pci 17.0 on  end # SATA
+		device pci 17.0 off end # SATA
 		device pci 19.0 off end # I2C 4
 		device pci 19.1 off end # I2C 5
 		device pci 19.2 off end # UART 2


### PR DESCRIPTION
The board does not support SATA disks. Despite the M.2 slots have the SATA lines, the silicon does not support the dynamic switching between SATA and PCIe. Disable the SATA controller to make Windows happy, as the straps are set for PCIe lanes.