### PR TITLE
Vault JSL Windows audio driver probe fix

### DIFF
--- a/src/include/smbios.h
+++ b/src/include/smbios.h
@@ -86,6 +86,7 @@ const char *smbios_chassis_version(void);
 const char *smbios_chassis_serial_number(void);
 const char *smbios_processor_serial_number(void);
 u8 smbios_chassis_power_cords(void);
+const char *smbios_chassis_sku(void);
 
 /* This string could be filled late in payload. */
 void smbios_type0_bios_version(uintptr_t address);

--- a/src/lib/smbios.c
+++ b/src/lib/smbios.c
@@ -498,6 +498,7 @@ static int smbios_write_type3(unsigned long *current, int handle)
 	t->asset_tag_number = smbios_add_string(t->eos, smbios_mainboard_asset_tag());
 	t->version = smbios_add_string(t->eos, smbios_chassis_version());
 	t->serial_number = smbios_add_string(t->eos, smbios_chassis_serial_number());
+	t->sku_number = smbios_add_string(t->eos, smbios_chassis_sku());
 	const int len = smbios_full_table_len(&t->header, t->eos);
 	*current += len;
 	return len;

--- a/src/lib/smbios_defaults.c
+++ b/src/lib/smbios_defaults.c
@@ -162,3 +162,8 @@ __weak u8 smbios_chassis_power_cords(void)
 {
 	return 1;
 }
+
+__weak const char *smbios_chassis_sku(void)
+{
+	return "";
+}

--- a/src/mainboard/protectli/vault_jsl/Kconfig
+++ b/src/mainboard/protectli/vault_jsl/Kconfig
@@ -33,6 +33,9 @@ config MAINBOARD_FAMILY
 	string
 	default "Vault"
 
+config OVERRIDE_DEVICETREE
+	default "overridetree_v1610.cb" if BOARD_PROTECTLI_V1610
+
 config DIMM_MAX
 	default 2
 

--- a/src/mainboard/protectli/vault_jsl/Kconfig
+++ b/src/mainboard/protectli/vault_jsl/Kconfig
@@ -31,7 +31,7 @@ config MAINBOARD_PART_NUMBER
 
 config MAINBOARD_FAMILY
 	string
-	default "Vault"
+	default "Protectli Vault"
 
 config OVERRIDE_DEVICETREE
 	default "overridetree_v1610.cb" if BOARD_PROTECTLI_V1610

--- a/src/mainboard/protectli/vault_jsl/devicetree.cb
+++ b/src/mainboard/protectli/vault_jsl/devicetree.cb
@@ -54,7 +54,6 @@ chip soc/intel/jasperlake
 	# Skip the CPU replacement check
 	register "SkipCpuReplacementCheck" = "1"
 
-	register "PchHdaDspEnable" = "1"
 	register "PchHdaAudioLinkHdaEnable" = "1"
 
 	# PCIe Root Port 1 and 2 for LAN3 and LAN4 on 4 port platform
@@ -68,7 +67,6 @@ chip soc/intel/jasperlake
 	register "PcieRpEnable[4]" = "1"
 	register "PcieRpEnable[5]" = "1"
 	register "PcieRpEnable[6]" = "1"
-
 
 	register "PcieClkSrcUsage[0]" = "PCIE_CLK_FREE" # WiFi
 	register "PcieClkSrcUsage[1]" = "PCIE_CLK_FREE" # M.2 NVMe

--- a/src/mainboard/protectli/vault_jsl/hda_verb.c
+++ b/src/mainboard/protectli/vault_jsl/hda_verb.c
@@ -6,13 +6,21 @@ const u32 cim_verb_data[] = {
 	/* JasperLake HDMI */
 	0x8086281a, /* Vendor ID */
 	0x80860101, /* Subsystem ID */
-	6, /* Number of entries */
+	8, /* Number of entries */
 	AZALIA_SUBVENDOR(2, 0x80860101),
+	0x00278111,
+	0x00278111,
+	0x00278111,
+	0x00278111,
 	AZALIA_PIN_CFG(2, 0x04, 0x18560010),
 	AZALIA_PIN_CFG(2, 0x06, 0x18560010),
 	AZALIA_PIN_CFG(2, 0x08, 0x18560010),
 	AZALIA_PIN_CFG(2, 0x0a, 0x18560010),
-	AZALIA_PIN_CFG(2, 0x0b, 0x18560010)
+	AZALIA_PIN_CFG(2, 0x0b, 0x18560010),
+	0x00278100,
+	0x00278100,
+	0x00278100,
+	0x00278100
 };
 
 const u32 pc_beep_verbs[] = {};

--- a/src/mainboard/protectli/vault_jsl/mainboard.c
+++ b/src/mainboard/protectli/vault_jsl/mainboard.c
@@ -202,6 +202,10 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 
 	params->PcieRpDetectTimeoutMs[1] = 200;
 
+	/* On V1610 the NVMe disk sometimes do not appear in RP with default 0ms timeout*/
+	if (CONFIG(BOARD_PROTECTLI_V1610))
+		params->PcieRpDetectTimeoutMs[3] = 200;
+
 	/*
 	 * HWP is too aggressive in power savings and does not let using full
 	 * bandwidth of Ethernet controllers without additional stressing of

--- a/src/mainboard/protectli/vault_jsl/mainboard.c
+++ b/src/mainboard/protectli/vault_jsl/mainboard.c
@@ -214,6 +214,12 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 	 * intel_pstate by disabling HWP.
 	 */
 	params->Hwp = 0;
+
+	/*
+	 * Skip PCI Subsystem IDs programming to match proprietary FW.
+	 * It also makes some Windows default drivers to probe successfully, e.g. audio.
+	 */
+	params->SiSkipSsidProgramming = 1;
 }
 
 static void mainboard_final(void *unused)

--- a/src/mainboard/protectli/vault_jsl/mainboard.c
+++ b/src/mainboard/protectli/vault_jsl/mainboard.c
@@ -3,10 +3,157 @@
 #include <arch/mmio.h>
 #include <device/device.h>
 #include <pc80/i8254.h>
+#include <device/pci_ids.h>
+#include <smbios.h>
 #include <soc/iomap.h>
+#include <soc/pci_devs.h>
 #include <soc/ramstage.h>
 
 #define FSP_PCH_PCIE_ASPM_L1 2
+
+smbios_enclosure_type smbios_mainboard_enclosure_type(void)
+{
+	return SMBIOS_ENCLOSURE_LOW_PROFILE_DESKTOP;
+}
+
+u8 smbios_mainboard_feature_flags(void)
+{
+	return SMBIOS_FEATURE_FLAGS_HOSTING_BOARD | SMBIOS_FEATURE_FLAGS_REPLACEABLE;
+}
+
+const char *smbios_system_sku(void)
+{
+	return CONFIG_MAINBOARD_PART_NUMBER "-01";
+}
+
+const char *smbios_chassis_sku(void)
+{
+	return CONFIG_MAINBOARD_PART_NUMBER "-001";
+}
+
+ const char *smbios_chassis_version(void)
+{
+	return "1.2";
+}
+
+static int smbios_type41_write_ethernet(struct device *parent, int *handle,
+					unsigned long *current)
+{
+	struct device *eth;
+	static u8 instance = 0;
+
+	if (!parent || !parent->enabled)
+		return 0;
+
+	eth = pcidev_path_behind(parent->link_list, PCI_DEVFN(0, 0));
+	if (!eth || !eth->enabled)
+		return 0;
+
+	/* Only i226 Ehternet Controller */
+	if (eth->vendor != PCI_VID_INTEL || eth->device != 0x125c)
+		return 0;
+
+	return smbios_write_type41(
+		current, handle,
+		"Onboard - Ethernet",		/* name */
+		instance++,			/* instance */
+		0,				/* segment */
+		eth->bus->secondary,		/* bus */
+		PCI_SLOT(eth->path.pci.devfn),	/* device */
+		PCI_FUNC(eth->path.pci.devfn),	/* function */
+		SMBIOS_DEVICE_TYPE_ETHERNET);	/* device type */
+}
+
+static int smbios_type41_write_ethernet_behind_switch(struct device *root_port, int *handle,
+						      unsigned long *current)
+{
+	struct device *switch_dev;
+	struct device *child;
+	int len = 0;
+
+	if (!root_port || !root_port->enabled)
+		return 0;
+
+	switch_dev = pcidev_path_behind(root_port->link_list, PCI_DEVFN(0, 0));
+	if (!switch_dev || !switch_dev->enabled)
+		return 0;
+
+	/* Only ASMedia switch */
+	if (switch_dev->vendor != 0x1b21 || switch_dev->device != 0x2806)
+		return 0;
+
+	/* After upstream port there is also one downstream port */
+	switch_dev = pcidev_path_behind(switch_dev->link_list, PCI_DEVFN(0, 0));
+	if (!switch_dev || !switch_dev->enabled)
+		return 0;
+
+	/* Only ASMedia switch */
+	if (switch_dev->vendor != 0x1b21 || switch_dev->device != 0x2806)
+		return 0;
+
+	/* Loop through all downstream ports of the switch */
+	for (child = switch_dev->bus->children; child; child = child->sibling) {
+		printk(BIOS_DEBUG, "Switch DS port %s [%04x:%04x]\n",
+			dev_path(child), child->vendor, child->device);
+		len += smbios_type41_write_ethernet(child, handle, current);
+	}
+
+	return len;
+}
+
+static int mainboard_smbios_data(struct device *dev, int *handle,
+				 unsigned long *current)
+{
+	int len = 0;
+
+	len += smbios_write_type41(
+		current, handle,
+		"Onboard - USB Controller",	/* name */
+		0,				/* instance */
+		0,				/* segment */
+		0,				/* bus */
+		PCH_DEV_SLOT_XHCI,		/* device */
+		0,				/* function */
+		SMBIOS_DEVICE_TYPE_OTHER);	/* device type */
+
+	len += smbios_write_type41(
+		current, handle,
+		"Onboard - HECI",		/* name */
+		0,				/* instance */
+		0,				/* segment */
+		0,				/* bus */
+		PCH_DEV_SLOT_CSE,		/* device */
+		0,				/* function */
+		SMBIOS_DEVICE_TYPE_OTHER);	/* device type */
+
+	len += smbios_write_type41(
+		current, handle,
+		"Onboard - eMMC",		/* name */
+		0,				/* instance */
+		0,				/* segment */
+		0,				/* bus */
+		PCH_DEV_SLOT_STORAGE,		/* device */
+		0,				/* function */
+		SMBIOS_DEVICE_TYPE_OTHER);	/* device type */
+
+	if (!CONFIG(BOARD_PROTECTLI_V1610)) {
+		len += smbios_type41_write_ethernet(PCH_DEV_PCIE1, handle, current);
+		len += smbios_type41_write_ethernet(PCH_DEV_PCIE2, handle, current);
+	} else {
+		len += smbios_type41_write_ethernet_behind_switch(PCH_DEV_PCIE1, handle,
+								  current);
+		len += smbios_type41_write_ethernet(PCH_DEV_PCIE5, handle, current);
+	}
+	len += smbios_type41_write_ethernet(PCH_DEV_PCIE6, handle, current);
+	len += smbios_type41_write_ethernet(PCH_DEV_PCIE7, handle, current);
+
+	return len;
+}
+
+static void mainboard_enable(struct device *dev)
+{
+	dev->ops->get_smbios_data = mainboard_smbios_data;
+}
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 {
@@ -73,4 +220,5 @@ static void mainboard_final(void *unused)
 
 struct chip_operations mainboard_ops = {
 	.final = mainboard_final,
+	.enable_dev = mainboard_enable,
 };

--- a/src/mainboard/protectli/vault_jsl/overridetree_v1610.cb
+++ b/src/mainboard/protectli/vault_jsl/overridetree_v1610.cb
@@ -1,0 +1,25 @@
+chip soc/intel/jasperlake
+	device domain 0 on
+		device pci 1c.0 on	# PCI Express Root Port 1
+			device pci 00.0 on # ASMedia Switch PCIe x2
+
+				device pci 00.0 on  end # ASMedia DS port 1 - LAN
+				device pci 02.0 on  end # ASMedia DS port 2 - LAN
+				device pci 06.0 on  end # ASMedia DS port 3 - LAN
+				device pci 0e.0 on	# ASMedia DS port 4
+					smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
+						 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"
+				end
+			end
+		end
+		device pci 1c.1 off end # PCI Express Root Port 2
+		device pci 1c.2 off end # PCI Express Root Port 3
+		device pci 1c.3 on	# PCI Express Root Port 4
+			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
+					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth1X"
+		end
+		device pci 1c.4 on  end # PCI Express Root Port 5 - LAN
+		device pci 1c.5 on  end # PCI Express Root Port 6 - LAN
+		device pci 1c.6 on  end # PCI Express Root Port 7 - LAN
+	end
+end


### PR DESCRIPTION
Eliminating differences in SMBIOS compared to proprietary firmware to make Windows Update happy.

UPDATE: SMBIOS did not help at all with fetching drivers. But skipping PCI SSID programming made the audio driver probe at least.