### PR TITLE
.github/workflows/build.yml: remove obesolete variable matrix.build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}-${{ matrix.build }}"
+          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}"
           path: |
             build/coreboot.rom
           retention-days: 30
@@ -71,7 +71,7 @@ jobs:
       - name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}-${{ matrix.build }}"
+          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}"
           path: |
             build/coreboot.rom
           retention-days: 30
@@ -99,7 +99,7 @@ jobs:
       - name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}-${{ matrix.build }}"
+          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}"
           path: |
             build/coreboot.rom
           retention-days: 30
@@ -132,7 +132,7 @@ jobs:
       - name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}-${{ matrix.build }}"
+          name: "dasharo-${{ matrix.vendor }}-${{ matrix.model }}-${{ matrix.payload }}"
           path: |
             build/coreboot.rom
           retention-days: 30


### PR DESCRIPTION
This should fix deploy failures like https://github.com/Dasharo/coreboot/actions/runs/10309184293/job/28539370198