### PR TITLE
soc/intel/meteorlake: Hook the VT-d DMA protection option

### DIFF
--- a/src/soc/intel/meteorlake/romstage/romstage.c
+++ b/src/soc/intel/meteorlake/romstage/romstage.c
@@ -156,4 +156,7 @@ void mainboard_romstage_entry(void)
 	pmc_set_disb();
 	if (!s3wake)
 		save_dimm_info();
+
+	if (CONFIG(ENABLE_EARLY_DMA_PROTECTION))
+		vtd_enable_dma_protection();`
 }


### PR DESCRIPTION
Applied Miczyg1's patch to coreboot alder lake https://review.coreboot.org/c/coreboot/+/68450 to meteor lake. It should hopefully fix this issue https://github.com/Dasharo/dasharo-issues/issues/985 but I can't test it now because of missing FSP.