### PR TITLE
.gitignore: Ignore both roms and their sha256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ site-local
 *.pyc
 *.sw[po]
 /*.rom
+*.rom.sha256
 .test
 .dependencies
 


### PR DESCRIPTION
Just a small change to cover more build artifacts