### PR TITLE
mb/clevo/mtl-h/ramstage.c: Add port reset message for USB ports 2 and 6

### DIFF
--- a/src/mainboard/clevo/mtl-h/ramstage.c
+++ b/src/mainboard/clevo/mtl-h/ramstage.c
@@ -230,4 +230,7 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 	params->PmcLpmS0ixSubStateEnableMask = BIT(0);
 
 	params->LidStatus = system76_ec_get_lid_state();
+
+	params->PortResetMessageEnable[1] = 1;
+	params->PortResetMessageEnable[5] = 1;
 }


### PR DESCRIPTION
These UPDs have to be set for PCH USB2.0 ports that are paired with CPU XHCI controller.