### PR TITLE
security/tpm: fix tis_drivers for postcar

### DIFF
--- a/src/security/tpm/tis.h
+++ b/src/security/tpm/tis.h
@@ -100,7 +100,7 @@ static inline bool tpm_first_access_this_boot(void)
 	(CONFIG(VBOOT_SEPARATE_VERSTAGE) && ENV_SEPARATE_VERSTAGE) ||  \
 	(CONFIG(VBOOT_STARTS_IN_ROMSTAGE) && ENV_RAMINIT) ||           \
 	(CONFIG(TPM_MEASURED_BOOT_INIT_BOOTBLOCK) && ENV_BOOTBLOCK) || \
-	(CONFIG(TPM_MEASURED_BOOT) && (ENV_RAMINIT || ENV_RAMSTAGE))
+	(CONFIG(TPM_MEASURED_BOOT) && (ENV_RAMINIT || ENV_POSTCAR || ENV_RAMSTAGE))
 #define __tis_driver __attribute__((used, section(".rodata.tis_driver")))
 #else
 #define __tis_driver __always_unused


### PR DESCRIPTION
postcar was missing in the list of stages that need tis_driver initialization.

This is security critical, because postcar can not measure the ramstage into the PCR, at least if the TPM is already initialized in the bootblock or verstage. This means the measurement chain is interrupted and the PCR values are „broken“, because the ramstage can be modified without changing the PCR value.