### PR TITLE
.github/workflows/build.yml: drop NovaCustom env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
           ${{ matrix.vendor }}_${{ matrix.model }}_ec.rom
         retention-days: 30
   build_novacustom:
-    environment: NovaCustom
     runs-on: ubuntu-22.04
     container:
       image: coreboot/coreboot-sdk:2023-11-24_2731fa619b


### PR DESCRIPTION
I moved novacustom secret from Environment to repo secrets and dropped environment usage. Should help with excessive deployment messages. Let's see if it still builds.