### PR TITLE
src/mainboard/protectli/vault_adl_n/acpi/usb_pd.asl: Add missing IRQ

### DIFF
--- a/src/mainboard/protectli/vault_adl_n/acpi/usb_pd.asl
+++ b/src/mainboard/protectli/vault_adl_n/acpi/usb_pd.asl
@@ -22,6 +22,11 @@ Scope (\_SB.PCI0.I2C4)
 			{
 				GPP_F13_IRQ
 			}
+			/* Linux driver expects one interrupt resource per one I2C dev */
+			Interrupt (ResourceConsumer, Level, ActiveLow)
+			{
+				GPP_F13_IRQ
+			}
 		})
 	}
 }


### PR DESCRIPTION
Should fix the error in dmesg:
`Serial bus multi instantiate pseudo device driver INT3515:00: error -ENXIO: IRQ index 1 not found`