### PR TITLE
build.sh: print usage when no argument is passed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -383,6 +383,11 @@ function build_odroid_h4 {
   fi
 }
 
+if [ $# -lt 1 ]; then
+  usage
+  exit
+fi
+
 CMD="$1"
 
 case "$CMD" in


### PR DESCRIPTION
Without it, the script failed with cryptic error:

    $ ./build.sh
    ./build.sh: line 259: $1: unbound variable