### PR TITLE
conform.yaml: update to coreboot guidelines

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -3,11 +3,11 @@ policies:
   - type: commit
     spec:
       header:
-        length: 80
+        length: 75
         imperative: false
         invalidLastCharacters: .
       body:
-        required: false
+        required: true
       dco: true
       gpg:
         required: true


### PR DESCRIPTION
Change first line of commit message from 80 to 75.

Set the commit body as required.

Source:
https://doc.coreboot.org/contributing/gerrit_guidelines.html#commit-message-guidelines

Change-Id: Iaab7a6a2c4adffa6b04b170b94cc98f3b157558e