### PR TITLE
iPXE: Native support for i218 MTL removed.

### DIFF
--- a/payloads/external/iPXE/Makefile
+++ b/payloads/external/iPXE/Makefile
@@ -4,7 +4,7 @@
 # When updating, change the name both here and in payloads/external/iPXE/Kconfig
 
 # Temporarily Dasharo fork is used until i225/i226 native support is merged.
-STABLE_COMMIT_ID=35d84756c8fc55b55922a24a8cd9e7ea27f92edb
+STABLE_COMMIT_ID=63ed3e352f2e65b26b15a847961440cb4dad0318
 
 TAG-$(CONFIG_IPXE_MASTER)=origin/master
 TAG-$(CONFIG_IPXE_STABLE)=$(STABLE_COMMIT_ID)

--- a/src/mainboard/clevo/mtl-h/Kconfig
+++ b/src/mainboard/clevo/mtl-h/Kconfig
@@ -145,6 +145,10 @@ config INCLUDE_NVIDIA_GPU_ASL
 	help
 	  Select this if the variant has an Nvidia GPU attached to RP12
 
+config PXE_ROM_ID
+	string
+	default "8086,550a" if BOARD_CLEVO_V5X0TU_BASE
+
 if PAYLOAD_EDK2
 
 config EDK2_CPU_THROTTLING_THRESHOLD_DEFAULT


### PR DESCRIPTION
iPXE payload commit changed to 63ed3e3, fix fot issue #1142