### PR TITLE
nb/intel/sandybridge/northbridge.c: Disbale non-active PEG devices

### DIFF
--- a/src/northbridge/intel/sandybridge/northbridge.c
+++ b/src/northbridge/intel/sandybridge/northbridge.c
@@ -267,17 +267,17 @@ static void disable_peg(void)
 	reg = pci_read_config32(dev, DEVEN);
 
 	dev = pcidev_on_root(1, 2);
-	if (!dev || !dev->enabled) {
+	if (!dev || !dev->enabled || !dev_is_active_bridge(dev)) {
 		printk(BIOS_DEBUG, "Disabling PEG12.\n");
 		reg &= ~DEVEN_PEG12;
 	}
 	dev = pcidev_on_root(1, 1);
-	if (!dev || !dev->enabled) {
+	if (!dev || !dev->enabled || !dev_is_active_bridge(dev)) {
 		printk(BIOS_DEBUG, "Disabling PEG11.\n");
 		reg &= ~DEVEN_PEG11;
 	}
 	dev = pcidev_on_root(1, 0);
-	if (!dev || !dev->enabled) {
+	if (!dev || !dev->enabled || !dev_is_active_bridge(dev)) {
 		printk(BIOS_DEBUG, "Disabling PEG10.\n");
 		reg &= ~DEVEN_PEG10;
 	}
@@ -292,7 +292,7 @@ static void disable_peg(void)
 		reg &= ~DEVEN_D4EN;
 	}
 	dev = pcidev_on_root(6, 0);
-	if (!dev || !dev->enabled) {
+	if (!dev || !dev->enabled || !dev_is_active_bridge(dev)) {
 		printk(BIOS_DEBUG, "Disabling PEG60.\n");
 		reg &= ~DEVEN_PEG60;
 	}


### PR DESCRIPTION
TXT SINIT ACM checks the PEG bridge memory ranges whether they are correctly assigned in the MMIO space. If the bridge is enabled but no device is attached to it, coreboot will not assign any resources (if hotplug is not enabled). When SINIT ACM checks the ranges, it fails on prefetchable range check.

Hide the PEG devices if the bridge is not active. PCIe bridges should generally be hidden if hotplug is not enabled and there is no downstream device.

Upstream-status: TBD