### PR TITLE
mb/msi/ms7d25,7eo6: Fix USB 3.x port mapping

### DIFF
--- a/src/mainboard/msi/ms7d25/devicetree.cb
+++ b/src/mainboard/msi/ms7d25/devicetree.cb
@@ -57,33 +57,33 @@ chip soc/intel/alderlake
 					 "M2_1" "SlotDataBusWidth4X"
 		end
 		device ref xhci on
-			register "usb2_ports[0]" = "USB2_PORT_SHORT(OC2)" # USB-C LAN_USB1
-			register "usb2_ports[1]" = "USB2_PORT_SHORT(OC1)" # MSI MYSTIC LIGHT
-			register "usb2_ports[2]" = "USB2_PORT_SHORT(OC0)" # USB-A LAN_USB1
-			register "usb2_ports[3]" = "USB2_PORT_LONG(OC0)" # JUSB5
-			register "usb2_ports[4]" = "USB2_PORT_SHORT(OC3)" # HUB to rear USB 2.0
-			register "usb2_ports[5]" = "USB2_PORT_LONG(OC3)" # empty?
-			register "usb2_ports[6]" = "USB2_PORT_LONG(OC7)" # JUSB4
-			register "usb2_ports[7]" = "USB2_PORT_LONG(OC0)" # JUSB4
-			register "usb2_ports[8]" = "USB2_PORT_LONG(OC2)" # JUSB3
-			register "usb2_ports[9]" = "USB2_PORT_LONG(OC7)" # JUSB3
-			register "usb2_ports[10]" = "USB2_PORT_SHORT(OC0)" # PS2_USB1
-			register "usb2_ports[11]" = "USB2_PORT_SHORT(OC0)" # PS2_USB1
-			register "usb2_ports[12]" = "USB2_PORT_SHORT(OC0)" # HUB to USB 2.0 headers
-			register "usb2_ports[13]" = "USB2_PORT_SHORT(OC6)" # CNVi BT
+			register "usb2_ports[0]" = "USB2_PORT_LONG(OC0)" # USB-C LAN_USB1
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC0)" # MSI MYSTIC LIGHT
+			register "usb2_ports[2]" = "USB2_PORT_LONG(OC1)" # USB-A LAN_USB1
+			register "usb2_ports[3]" = "USB2_PORT_LONG(OC1)" # JUSB5
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC2)" # HUB to rear USB 2.0
+			register "usb2_ports[5]" = "USB2_PORT_EMPTY"
+			register "usb2_ports[6]" = "USB2_PORT_LONG(OC3)" # JUSB4
+			register "usb2_ports[7]" = "USB2_PORT_LONG(OC3)" # JUSB4
+			register "usb2_ports[8]" = "USB2_PORT_LONG(OC4)" # JUSB3
+			register "usb2_ports[9]" = "USB2_PORT_LONG(OC4)" # JUSB3
+			register "usb2_ports[10]" = "USB2_PORT_LONG(OC5)" # PS2_USB1
+			register "usb2_ports[11]" = "USB2_PORT_LONG(OC5)" # PS2_USB1
+			register "usb2_ports[12]" = "USB2_PORT_MID(OC6)" # HUB to USB 2.0 headers
+			register "usb2_ports[13]" = "USB2_PORT_LONG(OC6)" # CNVi BT
 			register "usb2_ports[14]" = "USB2_PORT_EMPTY" # USB Redirection port 1
 			register "usb2_ports[15]" = "USB2_PORT_EMPTY" # USB Redirection port 2
 
-			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC2)" # USB-C LAN_USB1
-			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC2)" # USB-A LAN_USB1
-			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC3)" # JUSB5
-			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC0)" # USB-A USB2
-			register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC7)" # USB-A USB2
-			register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC7)" # JUSB4
-			register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC2)" # JUSB4
-			register "usb3_ports[7]" = "USB3_PORT_DEFAULT(OC2)" # JUSB3
-			register "usb3_ports[8]" = "USB3_PORT_DEFAULT(OC0)" # JUSB3
-			register "usb3_ports[9]" = "USB3_PORT_EMPTY"
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC0)" # USB-C Gen2x2 LAN_USB1
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC0)" # USB-C Gen2x2 LAN_USB1
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC1)" # USB-A LAN_USB1
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC1)" # JUSB5
+			register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC2)" # USB-A USB2
+			register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC2)" # USB-A USB2
+			register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC3)" # JUSB4
+			register "usb3_ports[7]" = "USB3_PORT_DEFAULT(OC3)" # JUSB4
+			register "usb3_ports[8]" = "USB3_PORT_DEFAULT(OC4)" # JUSB3
+			register "usb3_ports[9]" = "USB3_PORT_DEFAULT(OC4)" # JUSB3
 		end
 		device ref cnvi_wifi on
 			# Enable CNVi BT

--- a/src/mainboard/msi/ms7e06/devicetree.cb
+++ b/src/mainboard/msi/ms7e06/devicetree.cb
@@ -58,34 +58,33 @@ chip soc/intel/alderlake
 		end
 		device ref crashlog off end
 		device ref xhci on
-			# USB Configuration
-			register "usb2_ports[0]" = "USB2_PORT_SHORT(OC2)" # USB-C LAN_USB1
-			register "usb2_ports[1]" = "USB2_PORT_SHORT(OC1)" # MSI MYSTIC LIGHT
-			register "usb2_ports[2]" = "USB2_PORT_SHORT(OC0)" # USB-A LAN_USB1
-			register "usb2_ports[3]" = "USB2_PORT_LONG(OC0)" # JUSB5
-			register "usb2_ports[4]" = "USB2_PORT_SHORT(OC3)" # HUB to rear USB 2.0
-			register "usb2_ports[5]" = "USB2_PORT_LONG(OC3)" # empty?
-			register "usb2_ports[6]" = "USB2_PORT_LONG(OC7)" # JUSB4
-			register "usb2_ports[7]" = "USB2_PORT_LONG(OC0)" # JUSB4
-			register "usb2_ports[8]" = "USB2_PORT_LONG(OC2)" # JUSB3
-			register "usb2_ports[9]" = "USB2_PORT_LONG(OC7)" # JUSB3
-			register "usb2_ports[10]" = "USB2_PORT_SHORT(OC0)" # PS2_USB1
-			register "usb2_ports[11]" = "USB2_PORT_SHORT(OC0)" # PS2_USB1
-			register "usb2_ports[12]" = "USB2_PORT_SHORT(OC0)" # HUB to USB 2.0 headers
-			register "usb2_ports[13]" = "USB2_PORT_SHORT(OC6)" # CNVi BT
+			register "usb2_ports[0]" = "USB2_PORT_LONG(OC0)" # USB-C LAN_USB1
+			register "usb2_ports[1]" = "USB2_PORT_MID(OC0)" # MSI MYSTIC LIGHT
+			register "usb2_ports[2]" = "USB2_PORT_LONG(OC1)" # USB-A LAN_USB1
+			register "usb2_ports[3]" = "USB2_PORT_LONG(OC1)" # JUSB5
+			register "usb2_ports[4]" = "USB2_PORT_MID(OC2)" # HUB to rear USB 2.0
+			register "usb2_ports[5]" = "USB2_PORT_EMPTY"
+			register "usb2_ports[6]" = "USB2_PORT_LONG(OC3)" # JUSB4
+			register "usb2_ports[7]" = "USB2_PORT_LONG(OC3)" # JUSB4
+			register "usb2_ports[8]" = "USB2_PORT_LONG(OC4)" # JUSB3
+			register "usb2_ports[9]" = "USB2_PORT_LONG(OC4)" # JUSB3
+			register "usb2_ports[10]" = "USB2_PORT_LONG(OC5)" # PS2_USB1
+			register "usb2_ports[11]" = "USB2_PORT_LONG(OC5)" # PS2_USB1
+			register "usb2_ports[12]" = "USB2_PORT_MID(OC6)" # HUB to USB 2.0 headers
+			register "usb2_ports[13]" = "USB2_PORT_LONG(OC6)" # CNVi BT
 			register "usb2_ports[14]" = "USB2_PORT_EMPTY" # USB Redirection port 1
 			register "usb2_ports[15]" = "USB2_PORT_EMPTY" # USB Redirection port 2
 
-			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC2)" # USB-C LAN_USB1
-			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC2)" # USB-A LAN_USB1
-			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC3)" # JUSB5
-			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC0)" # USB-A USB2
-			register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC7)" # USB-A USB2
-			register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC7)" # JUSB4
-			register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC2)" # JUSB4
-			register "usb3_ports[7]" = "USB3_PORT_DEFAULT(OC2)" # JUSB3
-			register "usb3_ports[8]" = "USB3_PORT_DEFAULT(OC0)" # JUSB3
-			register "usb3_ports[9]" = "USB3_PORT_EMPTY"
+			register "usb3_ports[0]" = "USB3_PORT_DEFAULT(OC0)" # USB-C Gen2x2 LAN_USB1
+			register "usb3_ports[1]" = "USB3_PORT_DEFAULT(OC0)" # USB-C Gen2x2 LAN_USB1
+			register "usb3_ports[2]" = "USB3_PORT_DEFAULT(OC1)" # USB-A LAN_USB1
+			register "usb3_ports[3]" = "USB3_PORT_DEFAULT(OC1)" # JUSB5
+			register "usb3_ports[4]" = "USB3_PORT_DEFAULT(OC2)" # USB-A USB2
+			register "usb3_ports[5]" = "USB3_PORT_DEFAULT(OC2)" # USB-A USB2
+			register "usb3_ports[6]" = "USB3_PORT_DEFAULT(OC3)" # JUSB4
+			register "usb3_ports[7]" = "USB3_PORT_DEFAULT(OC3)" # JUSB4
+			register "usb3_ports[8]" = "USB3_PORT_DEFAULT(OC4)" # JUSB3
+			register "usb3_ports[9]" = "USB3_PORT_DEFAULT(OC4)" # JUSB3
 		end
 		device ref cnvi_wifi on
 			# Enable CNVi BT


### PR DESCRIPTION
The USB-C port is Gen2x2 and occupies two USB3.x line pairs. The missing second pair caused all the ports to be shifted by one and port 10 not being enabled as USB3.x capable. As a result one of the JUSB3 ports was working in HighSpeed only.

Also revise the USB OC mappings again and put correct OC pins to macros.