### PR TITLE
mb/novacustom/mtl-h: enable RTD3 on card reader

### DIFF
--- a/src/mainboard/novacustom/mtl-h/devicetree.cb
+++ b/src/mainboard/novacustom/mtl-h/devicetree.cb
@@ -210,6 +210,11 @@ chip soc/intel/meteorlake
 				register "enable_power_saving" = "1"
 				device pci 00.0 on end
 			end
+			chip soc/intel/common/block/pcie/rtd3
+				register "is_storage" = "true"
+				register "srcclk_pin" = "3"
+				device generic 0 on end
+			end
 		end
 		device ref pcie_rp8 on # M.2 2230
 			register "pcie_rp[PCH_RP(8)]" = "{


### PR DESCRIPTION
Add a RTD3 config to allow platform to enter S0ix. Fixes lack of SLP_S0 assertion in s2idle on Ubuntu 24.04.

Upstream-Status: Pending
Change-Id: Ifec0cf757cbce6ec880a63d31fe103bc1e782b46