### PR TITLE
Novacustom MTL-H S0ix fix

### DIFF
--- a/src/soc/intel/common/block/cse/cse.c
+++ b/src/soc/intel/common/block/cse/cse.c
@@ -1601,24 +1601,9 @@ static void cse_final(struct device *dev)
 		cse_final_end_of_firmware();
 }
 
-#if ENV_RAMSTAGE
-static void heci_read_resources(struct device *dev)
-{
-	/* Read standard PCI resources. */
-	pci_dev_read_resources(dev);
-
-	if (ENV_X86_32) {
-		/* Put resource below 4G to ensure coreboot can access it */
-		struct resource *res = find_resource(dev, PCI_BASE_ADDRESS_0);
-		res->limit = 0xffffffff;
-		res->flags &= ~IORESOURCE_ABOVE_4G;
-	}
-}
-#endif
-
 struct device_operations cse_ops = {
 	.set_resources		= pci_dev_set_resources,
-	.read_resources		= heci_read_resources,
+	.read_resources		= pci_dev_read_resources,
 	.enable_resources	= pci_dev_enable_resources,
 	.init			= pci_dev_init,
 	.ops_pci		= &pci_dev_ops_pci,

--- a/src/soc/intel/common/block/graphics/graphics.c
+++ b/src/soc/intel/common/block/graphics/graphics.c
@@ -288,13 +288,6 @@ static void graphics_dev_read_resources(struct device *dev)
 		pci_dev_set_resources(dev);
 		res_bar0->flags |= IORESOURCE_FIXED;
 	}
-
-	if (ENV_X86_32) {
-		/* Place framebuffer below 4G to ensure coreboot can access it */
-		struct resource *res_bar2 = find_resource(dev, PCI_BASE_ADDRESS_2);
-		res_bar2->limit = 0xffffffff;
-		res_bar2->flags &= ~IORESOURCE_ABOVE_4G;
-	}
 }
 
 static void graphics_join_mbus(void)

--- a/src/soc/intel/common/block/i2c/i2c.c
+++ b/src/soc/intel/common/block/i2c/i2c.c
@@ -134,19 +134,6 @@ uintptr_t dw_i2c_base_address(unsigned int bus)
 	return (uintptr_t)ALIGN_DOWN(pci_read_config32(dev, PCI_BASE_ADDRESS_0), 16);
 }
 
-static void dw_i2c_read_resources(struct device *dev)
-{
-	/* Read standard PCI resources. */
-	pci_dev_read_resources(dev);
-
-	if (ENV_X86_32) {
-		/* Put resource below 4G to ensure coreboot can access it */
-		struct resource *res = find_resource(dev, PCI_BASE_ADDRESS_0);
-		res->limit = 0xffffffff;
-		res->flags &= ~IORESOURCE_ABOVE_4G;
-	}
-}
-
 /*
  * This function ensures that the device is actually out of reset and
  * its ready for initialization sequence.
@@ -174,7 +161,7 @@ static void dw_i2c_device_init(struct device *dev)
 }
 
 struct device_operations i2c_dev_ops = {
-	.read_resources		= dw_i2c_read_resources,
+	.read_resources		= pci_dev_read_resources,
 	.set_resources		= pci_dev_set_resources,
 	.enable_resources	= pci_dev_enable_resources,
 	.scan_bus		= scan_static_bus,

--- a/src/soc/intel/meteorlake/Kconfig
+++ b/src/soc/intel/meteorlake/Kconfig
@@ -256,7 +256,7 @@ config PCR_BASE_ADDRESS
 
 config IOE_PCR_BASE_ADDRESS
 	hex
-	default 0x60000000
+	default 0x3fff0000000
 	help
 	  This option allows you to select MMIO Base Address of IOE sideband bus.
 

--- a/src/soc/intel/meteorlake/include/soc/iomap.h
+++ b/src/soc/intel/meteorlake/include/soc/iomap.h
@@ -66,10 +66,9 @@
 #define IOE_P2SB_BAR		IOE_PCR_ABOVE_4G_BASE_ADDR
 #define IOE_P2SB_SIZE		(256 * MiB)
 
-/* IOE_P2SB_BAR + 0xaa0000, but iasl refuses to perform arithmetics  */
-#define IOM_BASE_ADDR		0x60aa0000
+#define IOM_BASE_ADDR		0x3fff0aa0000
 #define IOM_BASE_SIZE		0x1600
-#define IOM_BASE_ADDR_MAX	0x60aa15ff
+#define IOM_BASE_ADDR_MAX	0x3fff0aa15ff
 
 /*
  * I/O port address space


### PR DESCRIPTION
These changes broke SLP_S0 assertion while in S2idle on Linux. Revert to restore S0ix functionality.