### PR TITLE
build.sh: Remove obtaining LAN ROM from regular NVC builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -223,6 +223,23 @@ function build_novacustom_v5x0tu {
 
   cp $DEFCONFIG .config
 
+  # Obtain LAN ROM blob from release binary
+  wget -O UEFIExtract_NE_A68_x64_linux.zip https://github.com/LongSoft/UEFITool/releases/download/A68/UEFIExtract_NE_A68_x64_linux.zip
+  unzip -o UEFIExtract_NE_A68_x64_linux.zip
+  wget -O novacustom_v54x_mtl_v0.9.0.rom https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_v54x_mtl/v0.9.0/novacustom_v54x_mtl_v0.9.0.rom
+
+  # Extract and transfer LAN ROM blob
+  docker run --rm -t -u $UID -v $PWD:/home/coreboot/coreboot \
+    -v $HOME/.ssh:/home/coreboot/.ssh \
+    -w /home/coreboot/coreboot coreboot/coreboot-sdk:$SDKVER \
+    /bin/bash -c "make -C util/cbfstool && \
+    util/cbfstool/cbfstool novacustom_v54x_mtl_v0.9.0.rom extract -r COREBOOT -f payload -n fallback/payload -m x86"
+
+  ./uefiextract payload DEB917C0-C56A-4860-A05B-BF2F22EBB717
+  mkdir -p 3rdparty/blobs/mainboard/novacustom/mtl-h
+  cp payload.dump/2\ 8C8CE578-8A3D-4F1C-9935-896185C32DD3/82\ DEB917C0-C56A-4860-A05B-BF2F22EBB717/1\ PE32\ image\ section/body.bin 3rdparty/blobs/mainboard/novacustom/mtl-h/LanRom.efi
+  rm -rf payload.dump
+
   echo "Building Dasharo for Novacustom $1 (version $FW_VERSION)"
 
   docker run --rm -t -u $UID -v $PWD:/home/coreboot/coreboot \
@@ -230,17 +247,7 @@ function build_novacustom_v5x0tu {
     -w /home/coreboot/coreboot coreboot/coreboot-sdk:$SDKVER \
     /bin/bash -c "make olddefconfig && make -j$(nproc)"
 
-  # Obtain LAN ROM blob from release binary
-  wget -O UEFIExtract_NE_A68_x64_linux.zip https://github.com/LongSoft/UEFITool/releases/download/A68/UEFIExtract_NE_A68_x64_linux.zip
-  unzip -o UEFIExtract_NE_A68_x64_linux.zip
-  wget -O novacustom_v54x_mtl_v0.9.0.rom https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_v54x_mtl/v0.9.0/novacustom_v54x_mtl_v0.9.0.rom
   cp build/coreboot.rom novacustom_$1_${FW_VERSION}.rom
-
-  # Extract and transfer LAN ROM blob
-  make -C util/cbfstool
-  util/cbfstool/cbfstool novacustom_v54x_mtl_v0.9.0.rom extract -r COREBOOT -f payload -n fallback/payload -m x86
-  ./uefiextract payload DEB917C0-C56A-4860-A05B-BF2F22EBB717
-  cp payload.dump/2\ 8C8CE578-8A3D-4F1C-9935-896185C32DD3/82\ DEB917C0-C56A-4860-A05B-BF2F22EBB717/1\ PE32\ image\ section/body.bin 3rdparty/blobs/mainboard/clevo/mtl-h/LanRom.efi
 
   if [ $? -eq 0 ]; then
     echo "Result binary placed in $PWD/novacustom_$1_${FW_VERSION}.rom"
@@ -444,9 +451,9 @@ case "$CMD" in
         BOARD="v560tu"
         build_novacustom_v5x0tu "v560tu"
         ;;
-    "v540tu " | "V540TU " )
+    "v540tu" | "V540TU" )
         BOARD="v540tu"
-        build_novacustom_v5x0tu "v540tu "
+        build_novacustom_v5x0tu "v540tu"
         ;;
     "apu2" | "APU2" )
         build_pcengines "apu2"

--- a/build.sh
+++ b/build.sh
@@ -198,12 +198,6 @@ function build_novacustom {
     -w /home/coreboot/coreboot coreboot/coreboot-sdk:$SDKVER \
     /bin/bash -c "make olddefconfig && make -j$(nproc)"
 
-  # Obtain LAN ROM blob from release binary
-  wget -O UEFIExtract_NE_A68_x64_linux.zip https://github.com/LongSoft/UEFITool/releases/download/A68/UEFIExtract_NE_A68_x64_linux.zip
-  unzip -o UEFIExtract_NE_A68_x64_linux.zip
-  wget -O novacustom_v54x_mtl_v0.9.0.rom https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_v54x_mtl/v0.9.0/novacustom_v54x_mtl_v0.9.0.rom
-  cp build/coreboot.rom novacustom_$1_${FW_VERSION}.rom
-
   if [ $? -eq 0 ]; then
     echo "Result binary placed in $PWD/novacustom_$1_${FW_VERSION}.rom"
     sha256sum novacustom_$1_${FW_VERSION}.rom > novacustom_$1_${FW_VERSION}.rom.sha256


### PR DESCRIPTION
The build_novacsutom function is used for boards that do not require LAN ROM. Remove obtaining the release binary and UEFIExtract as it is not used in the flow. Seems like a copy-pasta error.

Tested with `./build.sh v540tu`