### PR TITLE
Protectli JSL: Adding SuperIO UART to DSDT ACPI table.

### DIFF
--- a/src/mainboard/protectli/vault_jsl/acpi/superio.asl
+++ b/src/mainboard/protectli/vault_jsl/acpi/superio.asl
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#undef SUPERIO_DEV
+#undef SUPERIO_PNP_BASE
+#undef IT8613E_SHOW_UARTA
+#undef IT8613E_SHOW_KBC
+#undef IT8613E_SHOW_PS2M
+#define SUPERIO_DEV		SIO0
+#define SUPERIO_PNP_BASE	0x2e
+#define IT8613E_SHOW_UARTA	1
+
+#include <superio/ite/it8613e/acpi/superio.asl>

--- a/src/mainboard/protectli/vault_jsl/dsdt.asl
+++ b/src/mainboard/protectli/vault_jsl/dsdt.asl
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #include <acpi/acpi.h>
+
 DefinitionBlock(
 	"dsdt.aml",
 	"DSDT",
@@ -21,6 +22,10 @@ DefinitionBlock(
 			#include <soc/intel/common/block/acpi/acpi/northbridge.asl>
 			#include <soc/intel/jasperlake/acpi/southbridge.asl>
 		}
+	}
+
+	Scope (\_SB.PCI0.LPCB) {
+		#include "acpi/superio.asl"
 	}
 
 	#include <southbridge/intel/common/acpi/sleepstates.asl>


### PR DESCRIPTION
Adding IT8613 SIO0 to \_SB.PCI0.LPCB scope in dsdt.asl, adding acpi directory with superio.asl identical to EHL platform.