### PR TITLE
.pre-commit-config.yaml: add upstream-status check

### DIFF
--- a/.github/workflows/check-upstream-status.yml
+++ b/.github/workflows/check-upstream-status.yml
@@ -1,0 +1,19 @@
+name: check-upstream-status
+
+on:
+  pull_request:
+
+jobs:
+  check-upstream-status:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        # Checkout pull request HEAD commit instead of merge commit
+        # See: https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: check-upstream-status --hook-stage pre-push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,12 @@ repos:
         entry: util/lint/lint lint-stable
         language: script
         types: [file]
+
+  - repo: https://github.com/3mdeb/hooks
+    rev: v0.1.6
+    # Can be triggered manually with command:
+    # pre-commit run --hook-stage pre-push check-upstream-status
+    hooks:
+      - id: check-upstream-status
+        args: [--base, origin/dasharo]
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         types: [file]
 
   - repo: https://github.com/3mdeb/hooks
-    rev: v0.1.6
+    rev: v0.1.7
     # Can be triggered manually with command:
     # pre-commit run --hook-stage pre-push check-upstream-status
     hooks:


### PR DESCRIPTION
Move this check to pre-push rather then pre-commit, to avoid the possibility of losing longer commit message if pre-commit fails.

pre-push hook must be installed additionally to make it work (by default, only the pre-commit hook is installed)

pre-commit install -t pre-push
