### PR TITLE
CBnT: inject measurements made by BootGuard into event log

### DIFF
--- a/src/arch/x86/include/arch/fit_table.h
+++ b/src/arch/x86/include/arch/fit_table.h
@@ -3,7 +3,10 @@
 #ifndef _FIT_TABLE_H_
 #define _FIT_TABLE_H_
 
+#include <stddef.h>
 #include <stdint.h>
+
+#define FIT_POINTER_ADDRESS      0xffffffc0
 
 #define FIT_ENTRY_HAS_CHECKSUM   0x80
 
@@ -52,5 +55,38 @@ struct fit_entry {
 	uint8_t  type_checksum_valid;
 	uint8_t  checksum;
 } __packed;
+
+static inline uint32_t fit_entry_size(const struct fit_entry *entry)
+{
+	return entry->size_reserved & 0xffffff;
+}
+
+static inline uint8_t fit_entry_type(const struct fit_entry *entry)
+{
+	return entry->type_checksum_valid & 0x7f;
+}
+
+static inline struct fit_entry *fit_table_search(uint8_t entry_type)
+{
+	struct fit_entry *fit = *(struct fit_entry **)(uintptr_t)FIT_POINTER_ADDRESS;
+
+	union {
+		uint8_t bytes[sizeof(uint64_t)];
+		uint64_t u64;
+	} signature = { .bytes = {'_', 'F', 'I', 'T', '_', ' ', ' ', ' '} };
+
+	/* A quick sanity check that we're in fact dealing with FIT. */
+	if (fit->address.u64 != signature.u64)
+		return NULL;
+
+	int entry_count = fit_entry_size(fit) * 16 / sizeof(struct fit_entry);
+
+	for (int i = 0; i < entry_count; i++) {
+		if (fit_entry_type(&fit[i]) == entry_type)
+			return &fit[i];
+	}
+
+	return NULL;
+}
 
 #endif /* _FIT_TABLE_H_ */

--- a/src/arch/x86/include/arch/fit_table.h
+++ b/src/arch/x86/include/arch/fit_table.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef _FIT_TABLE_H_
+#define _FIT_TABLE_H_
+
+#include <stdint.h>
+
+#define FIT_ENTRY_HAS_CHECKSUM   0x80
+
+/*
+ * From "Firmware Interface Table, BIOS Specification" (document #599500), Rev. 1.6, March 2025
+ */
+#define FIT_ENTRY_TYPE_HEADER    0x00 // FIT Header Entry
+#define FIT_ENTRY_TYPE_UCODE     0x01 // Microcode Update Entry
+#define FIT_ENTRY_TYPE_SACM      0x02 // Startup AC Module Entry
+#define FIT_ENTRY_TYPE_DACM      0x03 // Diagnostic AC Module Entry
+#define FIT_ENTRY_TYPE_PBP       0x04 // Platform Boot Policy Entry
+#define FIT_ENTRY_TYPE_MMF       0x05 // Memory Microcontroller Firmware Entry
+#define FIT_ENTRY_TYPE_FRS       0x06 // FIT Reset State Entry
+#define FIT_ENTRY_TYPE_BIOS_SACM 0x07 // BIOS Startup Module Entry
+#define FIT_ENTRY_TYPE_TPM       0x08 // TPM Policy Record
+#define FIT_ENTRY_TYPE_BIOS      0x09 // BIOS Policy Record
+#define FIT_ENTRY_TYPE_TXT       0x0a // TXT Policy Record
+#define FIT_ENTRY_TYPE_KM        0x0b // Key Manifest Record
+#define FIT_ENTRY_TYPE_BPM       0x0c // Boot Policy Manifest
+#define FIT_ENTRY_TYPE_FSP       0x0d // FSP Boot Manifest
+// 0x0E - 0x0F Intel Reserved
+#define FIT_ENTRY_TYPE_CSE       0x10 // CSE Secure Boot
+// 0x11 - 0x19 Intel Reserved
+#define FIT_ENTRY_TYPE_VAB_PT    0x1a // Vendor Authorized Boot Provisioning Table
+#define FIT_ENTRY_TYPE_VAB_KM    0x1b // Vendor Authorized Boot Key Manifest
+#define FIT_ENTRY_TYPE_VAB_IM    0x1c // Vendor Authorized Boot Image Manifest
+#define FIT_ENTRY_TYPE_VAB_IH    0x1d // Vendor Authorized Boot Image Hash (Deprecated)
+#define FIT_ENTRY_TYPE_VAB_ACPIM 0x1e // VAB Authorization Code Patch Image Manifest
+// 0x1F - 0x2B Intel Reserved
+#define FIT_ENTRY_TYPE_SACM_DBG  0x2c // SACM Debug Record
+#define FIT_ENTRY_TYPE_FPDR      0x2d // Feature Policy Delivery Record.
+				      // Deprecated in CBnT platforms.
+#define FIT_ENTRY_TYPE_SCRTM_ERR 0x2e // Granular SCRTM Error Record
+#define FIT_ENTRY_TYPE_JMP_DBG   0x2f // JMP $ Debug Policy
+// 0x30 - 0x70 Reserved for Platform Manufacturer Use
+// 0x71 - 0x7E Intel Reserved
+#define FIT_ENTRY_TYPE_UNUSED    0x7f // Unused Entry (skip)
+
+struct fit_entry {
+	union {
+		uint8_t bytes[sizeof(uint64_t)];
+		uint64_t u64;
+	} address;
+	uint32_t size_reserved;
+	uint16_t version;
+	uint8_t  type_checksum_valid;
+	uint8_t  checksum;
+} __packed;
+
+#endif /* _FIT_TABLE_H_ */

--- a/src/cpu/intel/fit/fit_table.c
+++ b/src/cpu/intel/fit/fit_table.c
@@ -1,21 +1,13 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include <stdint.h>
-
-struct fit_entry {
-	uint8_t address[sizeof(uint64_t)];
-	uint32_t size_reserved;
-	uint16_t version;
-	uint8_t  type_checksum_valid;
-	uint8_t  checksum;
-} __packed;
+#include <arch/fit_table.h>
 
 __attribute((used)) static struct fit_entry fit_table[CONFIG_CPU_INTEL_NUM_FIT_ENTRIES + 1] = {
 	[0] = {
-		.address = {'_', 'F', 'I', 'T', '_', ' ', ' ', ' '},
+		.address.bytes = {'_', 'F', 'I', 'T', '_', ' ', ' ', ' '},
 		.size_reserved = 1,
 		.version = 0x100,
-		.type_checksum_valid = 0x80,
+		.type_checksum_valid = FIT_ENTRY_HAS_CHECKSUM | FIT_ENTRY_TYPE_HEADER,
 		.checksum = 0x7d,
 	}
 };

--- a/src/include/cpu/intel/msr.h
+++ b/src/include/cpu/intel/msr.h
@@ -10,6 +10,12 @@
 #define MSR_PIC_MSG_CONTROL	0x2e
 #define  TPR_UPDATES_DISABLE	(1 << 10)
 
+/* Public key hash of ACM signing key. */
+#define MSR_ACM_CPU_KEY_HASH_0	0x20
+#define MSR_ACM_CPU_KEY_HASH_1	0x21
+#define MSR_ACM_CPU_KEY_HASH_2	0x22
+#define MSR_ACM_CPU_KEY_HASH_3	0x23
+
 #define MSR_PLATFORM_INFO	0xce
 
 #define MSR_BC_PBEC		0x139

--- a/src/security/intel/cbnt/Makefile.mk
+++ b/src/security/intel/cbnt/Makefile.mk
@@ -5,6 +5,8 @@ ifeq ($(CONFIG_INTEL_CBNT_SUPPORT),y)
 all-y += logging.c
 ramstage-y += cmos.c
 
+bootblock-$(CONFIG_TPM_MEASURED_BOOT) += measurement.c
+
 # As specified in Intel Trusted Execution Technology and Boot Guard Server BIOS
 # Specification, document number # 558294
 PK_HASH_ALG_SHA1:=4

--- a/src/security/intel/cbnt/cbnt.h
+++ b/src/security/intel/cbnt/cbnt.h
@@ -12,6 +12,26 @@
 #define CBNT_BIOSACM_ERRORCODE (CBNT_BASE_ADDRESS + 0x328)
 #define CBNT_BIOSACM_POLICY_STS (CBNT_BASE_ADDRESS + 0x378)
 
+/* Measured Boot, if set Boot Guard ACM mesures IBB to TPM. */
+#define CBNT_BP_TYPE_M     (1 << 0)
+/* Verified Boot, Boot Guard ACM verifies IBB. */
+#define CBNT_BP_TYPE_V     (1 << 1)
+/* High Assurance Platform, the bit that is used to instruct ME to halt right after paltform
+   initialization. */
+#define CBNT_BP_TYPE_HAP   (1 << 2)
+/* TXT Supported. */
+#define CBNT_BP_TYPE_T     (1 << 3)
+#define CBNT_BP_RESERVED1  (1 << 4)
+/* Disable CPU debugging, if set DCI JTAG that would tamper with ACM execution is disabled. */
+#define CBNT_BP_RSTR_DCD   (1 << 5)
+/* Disable BSP #INIT, means to block INIT signals to mitigate code refetch. */
+#define CBNT_BP_RSTR_DBI   (1 << 6)
+/* Protect BIOS Environment, means Boot Guard ACM copies IBB to cache. */
+#define CBNT_BP_RSTR_PBE   (1 << 6)
+#define CBNT_BP_RESERVED2  (1 << 8)
+
+#define CBNT_EVENT_LOG_MESSAGE  "Boot Guard Measured S-CRTM"
+
 union cbnt_biosacm_policy {
 	struct {
 		uint64_t km_id : 4;
@@ -37,5 +57,9 @@ _Static_assert(sizeof(union cbnt_biosacm_policy) == sizeof(uint64_t),
 	       "Wrong size of cbnt_biosacm_policy");
 
 void intel_cbnt_log_registers(void);
+
+int intel_cbnt_get_locality(void);
+
+void intel_cbnt_inject_ibg_measurements(void);
 
 #endif

--- a/src/security/intel/cbnt/cbnt.h
+++ b/src/security/intel/cbnt/cbnt.h
@@ -12,6 +12,30 @@
 #define CBNT_BIOSACM_ERRORCODE (CBNT_BASE_ADDRESS + 0x328)
 #define CBNT_BIOSACM_POLICY_STS (CBNT_BASE_ADDRESS + 0x378)
 
+union cbnt_biosacm_policy {
+	struct {
+		uint64_t km_id : 4;
+		uint64_t bp : 9; /* See CBNT_BP_* constants. */
+		uint64_t tpm_type : 2;
+		uint64_t tpm_success : 1;
+		uint64_t: 1;
+		uint64_t pfr : 1;
+		uint64_t bckup_act : 2;
+		uint64_t txt_profile : 5;
+		uint64_t scrub_policy : 2;
+		uint64_t: 2;
+		uint64_t dma_protection : 1;
+		uint64_t: 2;
+		uint64_t scrtm_status : 3;
+		uint64_t cpu_co_signing : 1;
+		uint64_t tpm_startup_locality : 1;
+		uint64_t: 27;
+	} status;
+	uint64_t raw;
+};
+_Static_assert(sizeof(union cbnt_biosacm_policy) == sizeof(uint64_t),
+	       "Wrong size of cbnt_biosacm_policy");
+
 void intel_cbnt_log_registers(void);
 
 #endif

--- a/src/security/intel/cbnt/logging.c
+++ b/src/security/intel/cbnt/logging.c
@@ -111,30 +111,6 @@ union cbnt_biosacm_errorcode {
 _Static_assert(sizeof(union cbnt_biosacm_errorcode) == sizeof(uint32_t),
 	       "Wrong size of cbnt_biosacm_errorcode");
 
-union cbnt_biosacm_policy {
-	struct {
-		uint64_t km_id : 4;
-		uint64_t bp : 9;
-		uint64_t tpm_type : 2;
-		uint64_t tpm_success : 1;
-		uint64_t : 1;
-		uint64_t pfr : 1;
-		uint64_t bckup_act : 2;
-		uint64_t txt_profile : 5;
-		uint64_t scrub_policy : 2;
-		uint64_t : 2;
-		uint64_t dma_protection : 1;
-		uint64_t : 2;
-		uint64_t scrtm_status : 3;
-		uint64_t cpu_co_signing : 1;
-		uint64_t tpm_startup_locality : 1;
-		uint64_t : 27;
-	} status;
-	uint64_t raw;
-};
-_Static_assert(sizeof(union cbnt_biosacm_policy) == sizeof(uint64_t),
-	       "Wrong size of cbnt_biosacm_policy");
-
 static const char *decode_err_type(uint8_t type)
 {
 	switch (type) {

--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -3,6 +3,8 @@
 #include <arch/fit_table.h>
 #include <commonlib/iobuf.h>
 #include <console/console.h>
+#include <cpu/intel/msr.h>
+#include <cpu/x86/msr.h>
 #include <device/mmio.h>
 #include <security/intel/cbnt/cbnt.h>
 #include <security/tpm/tspi/crtm.h>
@@ -25,6 +27,13 @@
 #define BPM_IBBS_FLAG_FORCE_TME             (1 << 5)
 #define BPM_IBBS_FLAG_FORCE_IGN             (1 << 6)
 #define BPM_IBBS_FLAG_SRTM_AC               (1 << 7)
+
+/* Bits of `struct km_hash::usage` indicating to which public key the hash corresponds. */
+#define KM_HASH_USAGE_BPM       (1 << 0)
+#define KM_HASH_USAGE_FIT       (1 << 1)
+#define KM_HASH_USAGE_ACM       (1 << 2)
+#define KM_HASH_USAGE_SDEV      (1 << 3)
+#define KM_HASH_USAGE_PFR_CPLD  (1 << 4)
 
 /*
  * Definitions of the structures come from Intel document #575623 CBnT BWG v1.2.5 ("Intel
@@ -336,7 +345,83 @@ static enum cb_err fill_pcr0_km_fields(struct obuf *ob)
 	return err;
 }
 
-static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob)
+/* Finds public key used to sign Key Manifest and hashes it with the algorithm specified in the
+   header. */
+static enum cb_err hash_signature_key(const struct km_header *km, size_t km_len,
+				      struct vb2_hash *hash)
+{
+	/* All safety checks are in skip_signature_key() which is always run for PCR-0, so not
+	   bothering here for optional PCR-7 which is also computed after PCR-0. */
+	struct ibuf sig_ib;
+	ibuf_init(&sig_ib, (uint8_t *)km + km->key_sig_offset, km_len - km->key_sig_offset);
+
+	uint16_t key_alg;
+	(void)ibuf_read_le16(&sig_ib, &key_alg);
+
+	(void)ibuf_oob_drain(&sig_ib, 1); /* key signature version */
+	(void)ibuf_oob_drain(&sig_ib, 2); /* key algorithm */
+	(void)ibuf_oob_drain(&sig_ib, 1); /* key version */
+
+	uint16_t key_size;
+	(void)ibuf_read_le16(&sig_ib, &key_size);
+
+	size_t key_data_size = 0;
+	if (key_alg == TPM_ALG_RSA)
+		key_data_size = 4 + key_size / 8;   /* public exponent and public key */
+	else if (key_alg == TPM_ALG_ECC)
+		key_data_size = (key_size / 8) * 2; /* Qx + Qy */
+
+	if (vb2_hash_calculate(vboot_hwcrypto_allowed(), ibuf_oob_drain(&sig_ib, key_data_size),
+			       key_data_size, tpm2_alg_to_vb2_hash(km->km_pub_key_hash_alg),
+			       hash)) {
+		printk(BIOS_ERR, "CBnT: failed to hash PCR-0 measurement data\n");
+		return CB_ERR;
+	}
+
+	return CB_SUCCESS;
+}
+
+static enum cb_err fill_pcr7_km_fields(struct obuf *ob)
+{
+	size_t km_len;
+	const struct km_header *km = find_in_fit(FIT_ENTRY_TYPE_KM, &km_len);
+
+	struct vb2_hash km_pubkey_hash;
+	if (hash_signature_key(km, km_len, &km_pubkey_hash) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to hash Key Manifest's signature key\n");
+		return CB_ERR;
+	}
+
+	/* BP.KEY (hash of public part of the key used to sign Key Manifest) */
+	if (obuf_write(ob, km_pubkey_hash.raw, vb2_digest_size(km_pubkey_hash.algo))) {
+		printk(BIOS_ERR,
+		       "CBnT: failed to write hash of Key Manifest's signature key\n");
+		return CB_ERR;
+	}
+
+	/* Find hash that corresponds to BPM. */
+	const struct km_hash *key_hash = km->key_hash;
+	unsigned int i;
+	for (i = 0; i < km->key_count; ++i) {
+		if (key_hash->usage & KM_HASH_USAGE_BPM)
+			break;
+		key_hash = (const struct km_hash *)&key_hash->hash.data[key_hash->hash.size];
+	}
+	if (i == km->key_count) {
+		printk(BIOS_ERR, "CBnT: failed to find hash of BPM pubkey in KM\n");
+		return CB_ERR;
+	}
+
+	/* KM.BPKey.hashBuffer[BPM pubkey digest size] */
+	if (obuf_write(ob, key_hash->hash.data, key_hash->hash.size)) {
+		printk(BIOS_ERR, "CBnT: failed to write ACM signature\n");
+		return CB_ERR;
+	}
+
+	return CB_SUCCESS;
+}
+
+static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob, bool *auth_measure)
 {
 	size_t bpm_len;
 	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
@@ -356,6 +441,11 @@ static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob)
 	}
 
 	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
+	*auth_measure = (ibbs->flags & BPM_IBBS_FLAG_AUTH_MEASURE) != 0;
+
+	/* Auth data is measured only for TPM2. */
+	if (*auth_measure && tlcl_get_family() != TPM_2)
+		*auth_measure = false;
 
 	unsigned int i;
 	const struct hash_struct *ibb_hash = ibbs->digest_list.hashes;
@@ -377,6 +467,51 @@ static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob)
 	}
 
 	return CB_SUCCESS;
+}
+
+/*
+ * Pseudo-code of the data to be measured into PCR-7 for TigerLake and newer (older hardware
+ * isn't supported):
+ *
+ *     struct {
+ *         uint64_t ACM_POLICY_STATUS;
+ *         uint16_t ACM.Header.SVN;
+ *         uint8_t  ACM.KeyHash[32];
+ *         uint8_t  BP.KEY[32 or 48];  // Hash of the public key from Key Manifest's signature.
+ *         uint8_t  KM.BPKey.hashBuffer[BPM pubkey digest size];
+ *     } PCR7_DATA
+ *
+ * Applies only for TPM2.0.
+ *
+ * Returns true and initializes *hash on success.
+ */
+static bool make_pcr7_hash(struct obuf *ob, struct vb2_hash *hash)
+{
+	/*
+	 * ACM.KeyHash[32]
+	 *
+	 * BTG BWG says to use TXT.PUBLIC.KEY, but TXT SDG (#315168-017.4) and CBnT BWG say
+	 * that it doesn't contain anything useful on modern platforms utilizing SGX and
+	 * suggests to use MSRs 0x20::0x23.
+	 */
+	(void)obuf_write_le64(ob, rdmsr(MSR_ACM_CPU_KEY_HASH_0).raw);
+	(void)obuf_write_le64(ob, rdmsr(MSR_ACM_CPU_KEY_HASH_1).raw);
+	(void)obuf_write_le64(ob, rdmsr(MSR_ACM_CPU_KEY_HASH_2).raw);
+	(void)obuf_write_le64(ob, rdmsr(MSR_ACM_CPU_KEY_HASH_3).raw);
+
+	if (fill_pcr7_km_fields(ob) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to fill KM fields of PCR-7 measurement data\n");
+		return false;
+	}
+
+	size_t size;
+	const void *data = obuf_contents(ob, &size);
+	if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data, size, tpm_log_alg(), hash)) {
+		printk(BIOS_ERR, "CBnT: failed to hash PCR-7 measurement data\n");
+		return false;
+	}
+
+	return true;
 }
 
 int intel_cbnt_get_locality(void)
@@ -493,7 +628,8 @@ void intel_cbnt_inject_ibg_measurements(void)
 		return;
 	}
 
-	if (fill_pcr0_bpm_fields(&data_ob) != CB_SUCCESS) {
+	bool auth_measure;
+	if (fill_pcr0_bpm_fields(&data_ob, &auth_measure) != CB_SUCCESS) {
 		printk(BIOS_ERR, "CBnT: failed to fill BPM fields of PCR-0 measurement data\n");
 		return;
 	}
@@ -505,6 +641,20 @@ void intel_cbnt_inject_ibg_measurements(void)
 		return;
 	}
 
+	/* Making and hashing PCR-7 data. */
+	struct vb2_hash pcr7_hash;
+	if (auth_measure) {
+		/* Reuse the first 2 fields of PCR-0 data which are identical in both cases. */
+		obuf_init(&data_ob, data, sizeof(data));
+		(void)obuf_oob_fill(&data_ob, sizeof(uint64_t) + sizeof(uint16_t));
+
+		if (!make_pcr7_hash(&data_ob, &pcr7_hash)) {
+			printk(BIOS_ERR,
+			       "CBnT: failed to build and hash PCR-7 measurement data\n");
+			return;
+		}
+	}
+
 	/*
 	 * BWG suggests to Perform reconstruction at this point, but we are likely to continue
 	 * the boot anyway as Measured Boot failures generally aren't fatal and incorrect hash
@@ -514,5 +664,11 @@ void intel_cbnt_inject_ibg_measurements(void)
 	/* Per BWG this should be logged with EV_S_CRTM_CONTENTS type. */
 	tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 0, pcr0_hash.algo, pcr0_hash.raw,
 				vb2_digest_size(pcr0_hash.algo));
-	printk(BIOS_INFO, "CBnT: reconstructed PCR-0 measurement\n");
+	if (auth_measure) {
+		/* Per BWG this should be logged with EV_EFI_VARIABLE_DRIVER_CONFIG type and
+		   event name should be a Unicode string. */
+		tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 7, pcr7_hash.algo,
+					pcr7_hash.raw, vb2_digest_size(pcr7_hash.algo));
+		printk(BIOS_INFO, "CBnT: reconstructed PCR-7 measurement\n");
+	}
 }

--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -1,0 +1,518 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include <arch/fit_table.h>
+#include <commonlib/iobuf.h>
+#include <console/console.h>
+#include <device/mmio.h>
+#include <security/intel/cbnt/cbnt.h>
+#include <security/tpm/tspi/crtm.h>
+#include <security/vboot/misc.h>
+
+#define TPM_ALG_RSA     0x0001
+#define TPM_ALG_ECC     0x0023
+
+#define TPM_ALG_RSASSA  0x0014
+#define TPM_ALG_RSAPSS  0x0016
+#define TPM_ALG_ECDSA   0x0018
+#define TPM_ALG_SM2     0x001b
+
+/* Bits of `struct bpm_ibbs::flags`. */
+#define BPM_IBBS_FLAG_RESERVED1             (1 << 0) /* must be set to 1 */
+#define BPM_IBBS_FLAG_RESERVED2             (1 << 1) /* must be set to 1 */
+#define BPM_IBBS_FLAG_AUTH_MEASURE          (1 << 2) /* extend PCR-7 */
+#define BPM_IBBS_FLAG_CAP_PCRS_ON_TPM_FAIL  (1 << 3)
+#define BPM_IBBS_FLAG_TOP_SWAP_SUPPORTED    (1 << 4)
+#define BPM_IBBS_FLAG_FORCE_TME             (1 << 5)
+#define BPM_IBBS_FLAG_FORCE_IGN             (1 << 6)
+#define BPM_IBBS_FLAG_SRTM_AC               (1 << 7)
+
+/*
+ * Definitions of the structures come from Intel document #575623 CBnT BWG v1.2.5 ("Intel
+ * Converged Boot Guard and Intel Trusted Execution Technology (Intel TXT) BIOS Specification").
+ *
+ * Versions in structures could be different for other revisions of the document.
+ */
+
+/* Header of the Boot Policy Manifest. */
+struct bpm_header {
+	char structure_id[8];     /* "__ACBP__" */
+	uint8_t struct_ver;       /* 0x24 */
+	uint8_t hdr_struct_ver;   /* 0x20 */
+	uint16_t hdr_size;
+	uint16_t key_sig_offset;  /* offset to KeySignature field of Policy Manifest Signature
+				     Element (PMSE) */
+	uint8_t bpm_revision;
+	uint8_t bpm_svn;
+	uint8_t acmsvn_auth;
+	uint8_t reserved;
+	uint16_t nem_data_stack;  /* in 4 KiB pages */
+	uint8_t se_element[];
+} __packed;
+
+/* Deprecated uses must be initialized as { .alg = TPM_ALG_NULL (0x10), .size = 0 } */
+struct hash_struct {
+	uint16_t alg;
+	uint16_t size;
+	uint8_t data[];
+} __packed;
+
+struct bpm_hash_list {
+	uint16_t size;
+	uint16_t count;
+	struct hash_struct hashes[];
+} __packed;
+
+/* IBB Segment Element (upper part) */
+struct bpm_ibbs {
+	char structure_id[8];  /* "__IBBS__" */
+	uint8_t struct_ver;    /* 0x21 */
+	uint8_t reserved1;
+	uint16_t element_size;
+	uint8_t reserved2;
+	uint8_t set_number;    /* 0 */
+	uint8_t reserved3;
+	uint8_t pbet_value;
+	uint32_t flags;        /* see BPM_IBBS_FLAG_* constants for values */
+	uint64_t iommu_bar0;
+	uint64_t iommu_bar1;
+	uint32_t dma_prot_base0;
+	uint32_t dma_prot_limit0;
+	uint64_t dma_prot_base1;
+	uint64_t dma_prot_limit1;
+	struct hash_struct post_ibb_hash; /* deprecated since v1.2.0 of CBnT BWG */
+	uint32_t ibb_entry_point;
+	struct bpm_hash_list digest_list; /* each entries is of variable size */
+	/* struct bpm_ibbs_bottom bottom; */
+} __packed;
+
+/* IBB Segment Element (lower part) */
+struct bpm_ibbs_bottom {
+	struct hash_struct obb_hash; /* deprecated since v1.2.0 of CBnT BWG */
+	uint8_t reserved4[3];
+	uint8_t segment_count;
+	/* ibb_segments[segment_count]; */
+} __packed;
+
+/* KMHASH_STRUCT */
+struct km_hash {
+	uint64_t usage;           /* see KM_HASH_USAGE_* constants for values */
+	struct hash_struct hash;
+} __packed;
+
+/* Key Manifest */
+struct km_header {
+	char structure_id[8];       /* "__KEYM__" */
+	uint8_t struct_ver;         /* 0x21 */
+	uint8_t reserved1[3];
+	uint16_t key_sig_offset;
+	uint8_t reserved2[3];
+	uint8_t km_revision;
+	uint8_t km_svn;
+	uint8_t km_id;
+	uint16_t km_pub_key_hash_alg;
+	uint16_t key_count;
+	struct km_hash key_hash[];  /* of variable size */
+	/* key_sig_offset points here where Key Manifest Signature data is one
+	   of 2 Key Signature Structure formats: RSA or ECC / SM2. */
+} __packed;
+
+static const void *find_in_fit(uint8_t type, size_t *size)
+{
+	struct fit_entry *entry = fit_table_search(type);
+	if (entry == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find FIT entry: %#02x\n", type);
+		return NULL;
+	}
+
+	void *addr = (void *)(uintptr_t)entry->address.u64;
+
+	const struct acm_header_v0 *acm;
+	switch (type) {
+	case FIT_ENTRY_TYPE_SACM:
+		if (fit_entry_type(&entry[1]) == FIT_ENTRY_TYPE_SACM) {
+			/* A BIOS image can include more than Startup ACM, but this function
+			   always returns the first one which might be wrong. */
+			printk(BIOS_WARNING, "CBnT: picking SACM from FIT at random!\n");
+		}
+
+		/* All known versions of the header (up to v5.4) have compatible version and
+		   size fields. */
+		acm = (const struct acm_header_v0 *)addr;
+		if (acm->header_version[1] > 5 || acm->header_version[0] > 4) {
+			printk(BIOS_ERR, "CBnT: unsupported version of SACM: %d.%d\n",
+			       acm->header_version[1], acm->header_version[0]);
+			return NULL;
+		}
+
+		*size = acm->size * 4;
+		break;
+	case FIT_ENTRY_TYPE_KM:
+		if (fit_entry_type(&entry[1]) == FIT_ENTRY_TYPE_KM) {
+			/* A BIOS image can include more than one manifest, but this function
+			   always returns the first one which might be wrong. */
+			printk(BIOS_WARNING,
+			       "CBnT: picking Key Manifest from FIT at random!\n");
+		}
+		*size = fit_entry_size(entry);
+		break;
+	case FIT_ENTRY_TYPE_BPM:
+		*size = fit_entry_size(entry);
+		break;
+
+	default:
+		printk(BIOS_ERR, "CBnT: unexpected FIT entry type: %#02x\n", type);
+		return NULL;
+	}
+
+	return addr;
+}
+
+static enum cb_err fill_pcr0_acm_fields(struct obuf *ob)
+{
+	/* Not running any checks on the ACM like TXT code does, it must be correct if we got
+	   here. */
+	size_t acm_len;
+	const struct acm_header_v3 *acm = find_in_fit(FIT_ENTRY_TYPE_SACM, &acm_len);
+	if (acm == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find SACM\n");
+		return CB_ERR;
+	}
+
+	/*
+	 * ACM.Header.SVN (won't run out of space on this one).
+	 * All known versions of the header (up to v5.4) have compatible txt_svn field.
+	 */
+	(void)obuf_write_le16(ob, acm->txt_svn);
+
+	/* Versions v3.0 through v5.4 support CBnT and have this field in the same place. */
+	int err = obuf_write(ob, acm->rsa3072_sig, sizeof(acm->rsa3072_sig));
+	if (err)
+		printk(BIOS_ERR, "CBnT: failed to write ACM signature\n");
+
+	return err ? CB_ERR : CB_SUCCESS;
+}
+
+static enum cb_err skip_signature_key(struct ibuf *ib, uint16_t *key_alg)
+{
+	if (ibuf_read_le16(ib, key_alg)) {
+		printk(BIOS_ERR, "CBnT: failed to read key algorithm\n");
+		return CB_ERR;
+	}
+	if (*key_alg != TPM_ALG_RSA && *key_alg != TPM_ALG_ECC) {
+		printk(BIOS_ERR, "CBnT: unexpected public key algorithm: %#04x\n", *key_alg);
+		return CB_ERR;
+	}
+
+	uint8_t key_version;
+	if (ibuf_read_le8(ib, &key_version)) {
+		printk(BIOS_ERR, "CBnT: failed to read public key version\n");
+		return CB_ERR;
+	}
+	if (key_version != 0x10) {
+		printk(BIOS_ERR, "CBnT: unexpected version of public key: %#02x\n",
+		       key_version);
+		return CB_ERR;
+	}
+
+	uint16_t key_size;
+	if (ibuf_read_le16(ib, &key_size)) {
+		printk(BIOS_ERR, "CBnT: failed to read public key size\n");
+		return CB_ERR;
+	}
+
+	if (*key_alg == TPM_ALG_RSA) {
+		(void)ibuf_oob_drain(ib, 4);            /* public exponent */
+		(void)ibuf_oob_drain(ib, key_size / 8); /* the public key */
+	} else if (*key_alg == TPM_ALG_ECC) {
+		(void)ibuf_oob_drain(ib, key_size / 8); /* Qx */
+		(void)ibuf_oob_drain(ib, key_size / 8); /* Qy */
+	}
+
+	return CB_SUCCESS;
+}
+
+/* Copies a signature after parsing "RSA Key Signature Structure Format" or
+   "ECC / SM2 Key Signature Structure Format". */
+static enum cb_err copy_signature(struct ibuf ib, struct obuf *ob)
+{
+	uint8_t key_version;
+	if (ibuf_read_le8(&ib, &key_version)) {
+		printk(BIOS_ERR, "CBnT: failed to read key signature version\n");
+		return CB_ERR;
+	}
+	if (key_version != 0x10) {
+		printk(BIOS_ERR, "CBnT: unexpected key signature version: %#02x\n",
+		       key_version);
+		return CB_ERR;
+	}
+
+	uint16_t key_alg;
+	if (skip_signature_key(&ib, &key_alg) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to skip signature key\n");
+		return CB_ERR;
+	}
+
+	uint16_t sig_scheme;
+	if (ibuf_read_le16(&ib, &sig_scheme)) {
+		printk(BIOS_ERR, "CBnT: failed to read signature scheme\n");
+		return CB_ERR;
+	}
+	if (key_alg == TPM_ALG_RSA) {
+		if (sig_scheme != TPM_ALG_RSASSA && sig_scheme != TPM_ALG_RSAPSS) {
+			printk(BIOS_ERR, "CBnT: unexpected public signature scheme: %#04x\n",
+			       sig_scheme);
+			return CB_ERR;
+		}
+	} else if (key_alg == TPM_ALG_ECC) {
+		if (sig_scheme != TPM_ALG_ECDSA && sig_scheme != TPM_ALG_SM2) {
+			printk(BIOS_ERR, "CBnT: unexpected public signature scheme: %#04x\n",
+			       sig_scheme);
+			return CB_ERR;
+		}
+	}
+
+	uint8_t version;
+	if (ibuf_read_le8(&ib, &version)) {
+		printk(BIOS_ERR, "CBnT: failed to read signature version\n");
+		return CB_ERR;
+	}
+	if (version != 0x10) {
+		printk(BIOS_ERR, "CBnT: unexpected signature version: %#02x\n", version);
+		return CB_ERR;
+	}
+
+	uint16_t size;
+	if (ibuf_read_le16(&ib, &size)) {
+		printk(BIOS_ERR, "CBnT: failed to read signature size\n");
+		return CB_ERR;
+	}
+
+	uint16_t hash_alg;
+	if (ibuf_read_le16(&ib, &hash_alg)) {
+		printk(BIOS_ERR, "CBnT: failed to read hash algorithm of signature\n");
+		return CB_ERR;
+	}
+
+	size_t sig_size = 0;
+	if (key_alg == TPM_ALG_RSA) {
+		sig_size += size / 8; /* the signature */
+	} else if (key_alg == TPM_ALG_ECC) {
+		sig_size += size / 8; /* R */
+		sig_size += size / 8; /* S */
+	}
+
+	const void *sig_data = ibuf_oob_drain(&ib, sig_size);
+	if (sig_data == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to read signature\n");
+		return CB_ERR;
+	}
+
+	if (obuf_write(ob, sig_data, sig_size)) {
+		printk(BIOS_ERR, "CBnT: failed to write signature\n");
+		return CB_ERR;
+	}
+
+	return CB_SUCCESS;
+}
+
+static enum cb_err fill_pcr0_km_fields(struct obuf *ob)
+{
+	size_t km_len;
+	const struct km_header *km = find_in_fit(FIT_ENTRY_TYPE_KM, &km_len);
+	if (km == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find KM\n");
+		return CB_ERR;
+	}
+
+	struct ibuf km_sig_ib;
+	ibuf_init(&km_sig_ib, (const uint8_t *)km + km->key_sig_offset,
+		  km_len - km->key_sig_offset);
+
+	/* KM.Signature[KM signature size] */
+	enum cb_err err = copy_signature(km_sig_ib, ob);
+	if (err != CB_SUCCESS)
+		printk(BIOS_ERR, "CBnT: failed to copy KM signature\n");
+
+	return err;
+}
+
+static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob)
+{
+	size_t bpm_len;
+	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
+	if (bpm == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find BPM\n");
+		return CB_ERR;
+	}
+
+	struct ibuf bpm_sig_ib;
+	ibuf_init(&bpm_sig_ib, (const uint8_t *)bpm + bpm->key_sig_offset,
+		  bpm_len - bpm->key_sig_offset);
+
+	/* BPM.Signature[BPM signature size] */
+	if (copy_signature(bpm_sig_ib, ob) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to copy BPM signature\n");
+		return CB_ERR;
+	}
+
+	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
+
+	unsigned int i;
+	const struct hash_struct *ibb_hash = ibbs->digest_list.hashes;
+	for (i = 0; i < ibbs->digest_list.count; ++i) {
+		if (ibb_hash->alg == tpm2_alg_from_vb2_hash(tpm_log_alg()))
+			break;
+		ibb_hash = (const void *)&ibb_hash->data[ibb_hash->size];
+	}
+
+	if (i == ibbs->digest_list.count) {
+		printk(BIOS_ERR, "CBnT: failed to find matching IBB signature\n");
+		return CB_ERR;
+	}
+
+	/* IBB.Digest[IBB digest size] */
+	if (obuf_write(ob, ibb_hash->data, ibb_hash->size)) {
+		printk(BIOS_ERR, "CBnT: failed to write IBB signature\n");
+		return CB_ERR;
+	}
+
+	return CB_SUCCESS;
+}
+
+int intel_cbnt_get_locality(void)
+{
+	union cbnt_biosacm_policy biosacm_sts = {
+		.raw = read64p(CBNT_BIOSACM_POLICY_STS),
+	};
+
+	/* It's 0 without active CBnT. */
+	if (biosacm_sts.status.scrtm_status == 0)
+		return 0;
+
+	return biosacm_sts.status.tpm_startup_locality == 0 ? 3 : 0;
+}
+
+static enum cb_err cap_pcrs(union cbnt_biosacm_policy biosacm_sts)
+{
+	/* TODO: when adding support of all active PCR banks to Measured Boot, implement
+	         capping those PCRs for which there is no corresponding IBB digest in BPM. */
+
+	/* Nothing to do if there was no TPM failure. */
+	if (biosacm_sts.status.tpm_success)
+		return CB_SUCCESS;
+
+	size_t bpm_len;
+	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
+	if (bpm == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find BPM\n");
+		return CB_ERR;
+	}
+
+	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
+
+	/* Alternative to capping is disabling the TPM which requires no event log entries. */
+	if (!(ibbs->flags & BPM_IBBS_FLAG_CAP_PCRS_ON_TPM_FAIL))
+		return CB_SUCCESS;
+
+	const uint32_t separator = 0x00000001;
+	struct vb2_hash hash;
+	if (vb2_hash_calculate(vboot_hwcrypto_allowed(), &separator, sizeof(separator),
+			       tpm_log_alg(), &hash)) {
+		printk(BIOS_ERR, "CBnT: failed to hash PCR separator\n");
+		return CB_ERR;
+	}
+
+	for (int pcr = 0; pcr < 8; pcr++) {
+		tpm_log_add_table_entry("CBnT hit TPM failure during boot", pcr, hash.algo,
+					hash.raw, vb2_digest_size(hash.algo));
+		printk(BIOS_INFO, "CBnT: capped PCR-%d\n", pcr);
+	}
+	return CB_SUCCESS;
+}
+
+void intel_cbnt_inject_ibg_measurements(void)
+{
+	const union cbnt_biosacm_policy biosacm_sts = {
+		.raw = read64p(CBNT_BIOSACM_POLICY_STS),
+	};
+
+	/* Do nothing if BootGuard wasn't involved in the boot process. */
+	if (biosacm_sts.status.scrtm_status == 0)
+		return;
+
+	/* Do nothing if BootGuard doesn't measure anything. */
+	if (!(biosacm_sts.status.bp & CBNT_BP_TYPE_M))
+		return;
+
+	if (cap_pcrs(biosacm_sts) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to cap PCRs\n");
+		return;
+	}
+
+	/* cap_pcrs() must have logged that PCRs were capped, nothing else to do on TPM error. */
+	if (!biosacm_sts.status.tpm_success) {
+		printk(BIOS_ERR, "CBnT: TPM failure detected\n");
+		return;
+	}
+
+	/*
+	 * Making and hashing PCR-7 data.
+	 *
+	 * Pseudo-code of the data to be measured into PCR-0 for TigerLake and newer (older
+	 * hardware isn't supported yet):
+	 *
+	 *     struct {
+	 *          uint64_t ACM_POLICY_STATUS;
+	 *          uint16_t ACM.Header.SVN;
+	 *          uint8_t  ACM.Signature[ACM signature size];
+	 *          uint8_t  KM.Signature[KM signature size];
+	 *          uint8_t  BPM.Signature[BPM signature size];
+	 *          uint8_t  IBB.Digest[IBB digest size];
+	 *     } PCR0_DATA;
+	 */
+
+	/*
+	 * Allow for 4 8192-bit digests in PCR-0 measurements which is an unlikely situation,
+	 * so this buffer should be enough to not run out of space (data measured into PCR-7 is
+	 * smaller).
+	 */
+	char data[sizeof(uint64_t) + sizeof(uint16_t) + 4 * KiB];
+	struct obuf data_ob;
+	obuf_init(&data_ob, data, sizeof(data));
+
+	/* ACM_POLICY_STATUS (won't run out of space on this one) */
+	(void)obuf_write_le64(&data_ob, biosacm_sts.raw);
+
+	if (fill_pcr0_acm_fields(&data_ob) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to fill ACM fields of PCR-0 measurement data\n");
+		return;
+	}
+
+	if (fill_pcr0_km_fields(&data_ob) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to fill KM fields of PCR-0 measurement data\n");
+		return;
+	}
+
+	if (fill_pcr0_bpm_fields(&data_ob) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to fill BPM fields of PCR-0 measurement data\n");
+		return;
+	}
+
+	struct vb2_hash pcr0_hash;
+	if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data, obuf_nr_written(&data_ob),
+			       tpm_log_alg(), &pcr0_hash)) {
+		printk(BIOS_ERR, "CBnT: failed to hash PCR-0 measurement data\n");
+		return;
+	}
+
+	/*
+	 * BWG suggests to Perform reconstruction at this point, but we are likely to continue
+	 * the boot anyway as Measured Boot failures generally aren't fatal and incorrect hash
+	 * will be caught later during the boot process.  So not bothering.
+	 */
+
+	/* Per BWG this should be logged with EV_S_CRTM_CONTENTS type. */
+	tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 0, pcr0_hash.algo, pcr0_hash.raw,
+				vb2_digest_size(pcr0_hash.algo));
+	printk(BIOS_INFO, "CBnT: reconstructed PCR-0 measurement\n");
+}

--- a/src/security/intel/txt/txt_register.h
+++ b/src/security/intel/txt/txt_register.h
@@ -229,6 +229,40 @@ struct __packed acm_header_v0 {
 	uint8_t user_area[];
 };
 
+/*
+ * ACM Header v3.0 without dynamic part
+ * Chapter A.1.1
+ * Intel TXT Software Development Guide (Document: 315168-017.4)
+ *
+ * This version adds support for CBnT.
+ */
+struct __packed acm_header_v3 {
+	uint16_t module_type;
+	uint16_t module_sub_type;
+	uint32_t header_len;
+	uint16_t header_version[2];
+	uint16_t chipset_id;
+	uint16_t flags;
+	uint32_t module_vendor;
+	uint32_t date;
+	uint32_t size;
+	uint16_t txt_svn;
+	uint16_t se_svn;
+	uint32_t code_control;
+	uint32_t error_entry_point;
+	uint32_t gdt_limit;
+	uint32_t gdt_ptr;
+	uint32_t seg_sel;
+	uint32_t entry_point;
+	uint8_t reserved2[64];
+	uint32_t key_size;
+	uint32_t scratch_size;
+	uint8_t rsa3072_pubkey[384];
+	uint8_t rsa3072_sig[384];
+	uint32_t scratch[208];
+	uint8_t user_area[];
+};
+
 struct __packed acm_info_table {
 	uint8_t uuid[16];
 	uint8_t chipset_acm_type;

--- a/src/security/tpm/tspi.h
+++ b/src/security/tpm/tspi.h
@@ -13,7 +13,6 @@
 
 #define TPM_PCR_MAX_LEN 64
 #define HASH_DATA_CHUNK_SIZE 1024
-#define MAX_TPM_LOG_ENTRIES 50
 /* Assumption of 2K TCPA log size reserved for CAR/SRAM */
 #define MAX_PRERAM_TPM_LOG_ENTRIES 15
 

--- a/src/security/tpm/tspi.h
+++ b/src/security/tpm/tspi.h
@@ -167,6 +167,16 @@ static inline void tpm_log_add_table_entry(const char *name, const uint32_t pcr,
 }
 
 /**
+ * Record startup locality in the event log.
+ */
+static inline void tpm_log_startup_locality(int locality)
+{
+	/* Locality 0 is the default and doesn't need to be logged. */
+	if (locality != 0 && tpm_log_use_tpm2_format())
+		tpm2_log_startup_locality(locality);
+}
+
+/**
  * Dump TPM log entries on console
  */
 static inline void tpm_log_dump(void *unused)

--- a/src/security/tpm/tspi/crtm.c
+++ b/src/security/tpm/tspi/crtm.c
@@ -8,6 +8,7 @@
 #include "crtm.h"
 #include <stdio.h>
 #include <string.h>
+#include <security/intel/cbnt/cbnt.h>
 
 static int tpm_log_initialized;
 static inline int tpm_log_available(void)
@@ -44,6 +45,14 @@ static tpm_result_t tspi_init_crtm(void)
 	} else {
 		printk(BIOS_WARNING, "TSPI: CRTM already initialized!\n");
 		return TPM_SUCCESS;
+	}
+
+	if (CONFIG(INTEL_CBNT_SUPPORT)) {
+		/* No need to create Startup Locality Event without CBnT as Locality 0 should be
+		   in use in that case and reporting it is optional. */
+		tpm_log_startup_locality(intel_cbnt_get_locality());
+
+		intel_cbnt_inject_ibg_measurements();
 	}
 
 	struct region_device fmap;
@@ -196,6 +205,20 @@ tpm_result_t tspi_measure_cache_to_pcr(void)
 	printk(BIOS_DEBUG, "TPM: Write digests cached in TPM log to PCR\n");
 	i = 0;
 	while (!tpm_log_get(i++, &pcr, &digest_data, &digest_algo, &event_name)) {
+		/*
+		 * Skip log entries that coreboot synthesized to account for PCR extends
+		 * performed by hardware S-CRTM.
+		 *
+		 * With CONFIG(INTEL_CBNT_SUPPORT) implying
+		 * CONFIG(TPM_MEASURED_BOOT_INIT_BOOTBLOCK) tpm_setup() (and thus
+		 * tspi_measure_cache_to_pcr()) should be invoked before CBNT measurements are
+		 * created, in fact we shouldn't even reach here because the log is likely
+		 * empty, but it seems more robust to have the check here.
+		 */
+		if (CONFIG(INTEL_CBNT_SUPPORT) &&
+		    strcmp(event_name, CBNT_EVENT_LOG_MESSAGE) == 0)
+			continue;
+
 		printk(BIOS_DEBUG, "TPM: Write digest for %s into PCR %d\n", event_name, pcr);
 		tpm_result_t rc = tlcl_extend(pcr, digest_data, digest_algo);
 		if (rc != TPM_SUCCESS) {

--- a/src/security/tpm/tspi/log-tpm1.c
+++ b/src/security/tpm/tspi/log-tpm1.c
@@ -14,6 +14,10 @@
 #include <cbmem.h>
 #include <vb2_sha.h>
 
+#define TPM_LOG_SIZE         (64 * KiB)
+#define MAX_TPM_LOG_ENTRIES  ((TPM_LOG_SIZE - sizeof(struct tpm_1_log_table)) /  \
+			      sizeof(struct tpm_1_log_entry))
+
 void *tpm1_log_cbmem_init(void)
 {
 	static struct tpm_1_log_table *tclt;
@@ -21,19 +25,17 @@ void *tpm1_log_cbmem_init(void)
 		return tclt;
 
 	if (ENV_HAS_CBMEM) {
-		size_t tpm_log_len;
 		struct spec_id_event_data *hdr;
 
 		tclt = cbmem_find(CBMEM_ID_TCPA_TCG_LOG);
 		if (tclt)
 			return tclt;
 
-		tpm_log_len = sizeof(*tclt) + MAX_TPM_LOG_ENTRIES * sizeof(tclt->entries[0]);
-		tclt = cbmem_add(CBMEM_ID_TCPA_TCG_LOG, tpm_log_len);
+		tclt = cbmem_add(CBMEM_ID_TCPA_TCG_LOG, TPM_LOG_SIZE);
 		if (!tclt)
 			return NULL;
 
-		memset(tclt, 0, tpm_log_len);
+		memset(tclt, 0, TPM_LOG_SIZE);
 		hdr = &tclt->spec_id;
 
 		/* Fill in first "header" entry. */

--- a/src/security/tpm/tspi/log-tpm2.c
+++ b/src/security/tpm/tspi/log-tpm2.c
@@ -22,6 +22,11 @@
 #include <cbmem.h>
 #include <vb2_sha.h>
 
+struct startup_locality_event {
+	char signature[16];       /* "StartupLocality" (NUL-terminated) */
+	uint8_t startup_locality; /* 0 or 3 */
+} __packed;
+
 void *tpm2_log_cbmem_init(void)
 {
 	static struct tpm_2_log_table *tclt;
@@ -147,6 +152,47 @@ void tpm2_log_add_table_entry(const char *name, const uint32_t pcr,
 	tce->data_length = htole32(sizeof(tce->data));
 	strncpy((char *)tce->data, name, sizeof(tce->data) - 1);
 	tce->data[sizeof(tce->data) - 1] = '\0';
+}
+
+void tpm2_log_startup_locality(int locality)
+{
+	_Static_assert(sizeof(struct startup_locality_event) <= TPM_20_LOG_DATA_MAX_LENGTH,
+		       "Data field of TCG log for TPM2 is too short for Startup Locality.\n");
+
+	struct tpm_2_log_table *tclt;
+	struct tpm_2_log_entry *tce;
+	struct startup_locality_event locality_event;
+
+	tclt = tpm_log_init();
+	if (!tclt) {
+		printk(BIOS_WARNING, "TPM LOG: non-existent!\n");
+		return;
+	}
+
+	if (le16toh(tclt->vendor.num_entries) >= le16toh(tclt->vendor.max_entries)) {
+		printk(BIOS_WARNING, "TPM LOG: log table is full\n");
+		return;
+	}
+
+	tce = &tclt->entries[le16toh(tclt->vendor.num_entries)];
+	tclt->vendor.num_entries = htole16(le16toh(tclt->vendor.num_entries) + 1);
+
+	/* EV_NO_ACTION events use PCR-0 by default. */
+	tce->pcr = htole32(0);
+	tce->event_type = htole32(EV_NO_ACTION);
+
+	/* EV_NO_ACTION events use zeroes for digest(s). */
+	tce->digest_count = htole32(1);
+	tce->digest_type = htole16(tpm2_alg_from_vb2_hash(tpm_log_alg()));
+	memset(tce->digest, 0, vb2_digest_size(tpm_log_alg()));
+
+	tce->data_length = htole32(sizeof(tce->data));
+
+	strcpy(locality_event.signature, "StartupLocality");
+	locality_event.startup_locality = locality;
+
+	memset(tce->data, 0, sizeof(tce->data));
+	memcpy(tce->data, &locality_event, sizeof(locality_event));
 }
 
 int tpm2_log_get(int entry_idx, int *pcr, const uint8_t **digest_data,

--- a/src/security/tpm/tspi/log-tpm2.c
+++ b/src/security/tpm/tspi/log-tpm2.c
@@ -22,6 +22,10 @@
 #include <cbmem.h>
 #include <vb2_sha.h>
 
+#define TPM_LOG_SIZE         (64 * KiB)
+#define MAX_TPM_LOG_ENTRIES  ((TPM_LOG_SIZE - sizeof(struct tpm_2_log_table)) /  \
+			      sizeof(struct tpm_2_log_entry))
+
 struct startup_locality_event {
 	char signature[16];       /* "StartupLocality" (NUL-terminated) */
 	uint8_t startup_locality; /* 0 or 3 */
@@ -34,20 +38,17 @@ void *tpm2_log_cbmem_init(void)
 		return tclt;
 
 	if (ENV_HAS_CBMEM) {
-		size_t tpm_log_len;
 		struct tcg_efi_spec_id_event *hdr;
 
 		tclt = cbmem_find(CBMEM_ID_TPM2_TCG_LOG);
 		if (tclt)
 			return tclt;
 
-		tpm_log_len = sizeof(struct tpm_2_log_table) +
-			MAX_TPM_LOG_ENTRIES * sizeof(struct tpm_2_log_entry);
-		tclt = cbmem_add(CBMEM_ID_TPM2_TCG_LOG, tpm_log_len);
+		tclt = cbmem_add(CBMEM_ID_TPM2_TCG_LOG, TPM_LOG_SIZE);
 		if (!tclt)
 			return NULL;
 
-		memset(tclt, 0, tpm_log_len);
+		memset(tclt, 0, TPM_LOG_SIZE);
 		hdr = &tclt->header;
 
 		hdr->event_type = htole32(EV_NO_ACTION);

--- a/src/security/tpm/tspi/log-tpm2.c
+++ b/src/security/tpm/tspi/log-tpm2.c
@@ -22,23 +22,6 @@
 #include <cbmem.h>
 #include <vb2_sha.h>
 
-static uint16_t tpmalg_from_vb2_hash(enum vb2_hash_algorithm hash_type)
-{
-	switch (hash_type) {
-	case VB2_HASH_SHA1:
-		return TPM2_ALG_SHA1;
-	case VB2_HASH_SHA256:
-		return TPM2_ALG_SHA256;
-	case VB2_HASH_SHA384:
-		return TPM2_ALG_SHA384;
-	case VB2_HASH_SHA512:
-		return TPM2_ALG_SHA512;
-
-	default:
-		return 0xFF;
-	}
-}
-
 void *tpm2_log_cbmem_init(void)
 {
 	static struct tpm_2_log_table *tclt;
@@ -71,7 +54,7 @@ void *tpm2_log_cbmem_init(void)
 		hdr->spec_errata = 0x00;
 		hdr->uintn_size = 0x02; // 64-bit UINT
 		hdr->num_of_algorithms = htole32(1);
-		hdr->digest_sizes[0].alg_id = htole16(tpmalg_from_vb2_hash(tpm_log_alg()));
+		hdr->digest_sizes[0].alg_id = htole16(tpm2_alg_from_vb2_hash(tpm_log_alg()));
 		hdr->digest_sizes[0].digest_size = htole16(vb2_digest_size(tpm_log_alg()));
 
 		tclt->vendor_info_size = sizeof(tclt->vendor);
@@ -158,7 +141,7 @@ void tpm2_log_add_table_entry(const char *name, const uint32_t pcr,
 	tce->event_type = htole32(EV_ACTION);
 
 	tce->digest_count = htole32(1);
-	tce->digest_type = htole16(tpmalg_from_vb2_hash(tpm_log_alg()));
+	tce->digest_type = htole16(tpm2_alg_from_vb2_hash(tpm_log_alg()));
 	memcpy(tce->digest, digest, vb2_digest_size(tpm_log_alg()));
 
 	tce->data_length = htole32(sizeof(tce->data));

--- a/src/security/tpm/tspi/log.c
+++ b/src/security/tpm/tspi/log.c
@@ -9,6 +9,8 @@
 #include <cbmem.h>
 #include <vb2_sha.h>
 
+#define MAX_TPM_LOG_ENTRIES  50
+
 void *tpm_cb_log_cbmem_init(void)
 {
 	static struct tpm_cb_log_table *tclt;

--- a/src/security/tpm/tspi/logs.h
+++ b/src/security/tpm/tspi/logs.h
@@ -3,6 +3,7 @@
 #ifndef LOGS_H_
 #define LOGS_H_
 
+#include <commonlib/bsd/tpm_log_defs.h>
 #include <stdint.h>
 #include <vb2_api.h>
 
@@ -50,5 +51,22 @@ void tpm2_log_add_table_entry(const char *name, const uint32_t pcr,
 			      const uint8_t *digest,
 			      const size_t digest_len);
 void tpm2_log_dump(void);
+
+static inline uint16_t tpm2_alg_from_vb2_hash(enum vb2_hash_algorithm hash_type)
+{
+	switch (hash_type) {
+	case VB2_HASH_SHA1:
+		return TPM2_ALG_SHA1;
+	case VB2_HASH_SHA256:
+		return TPM2_ALG_SHA256;
+	case VB2_HASH_SHA384:
+		return TPM2_ALG_SHA384;
+	case VB2_HASH_SHA512:
+		return TPM2_ALG_SHA512;
+
+	default:
+		return 0xFF;
+	}
+}
 
 #endif /* LOGS_H_ */

--- a/src/security/tpm/tspi/logs.h
+++ b/src/security/tpm/tspi/logs.h
@@ -50,6 +50,7 @@ void tpm2_log_add_table_entry(const char *name, const uint32_t pcr,
 			      enum vb2_hash_algorithm digest_algo,
 			      const uint8_t *digest,
 			      const size_t digest_len);
+void tpm2_log_startup_locality(int locality);
 void tpm2_log_dump(void);
 
 static inline uint16_t tpm2_alg_from_vb2_hash(enum vb2_hash_algorithm hash_type)

--- a/src/security/tpm/tspi/logs.h
+++ b/src/security/tpm/tspi/logs.h
@@ -70,4 +70,21 @@ static inline uint16_t tpm2_alg_from_vb2_hash(enum vb2_hash_algorithm hash_type)
 	}
 }
 
+static inline enum vb2_hash_algorithm tpm2_alg_to_vb2_hash(uint16_t hash_type)
+{
+	switch (hash_type) {
+	case TPM2_ALG_SHA1:
+		return VB2_HASH_SHA1;
+	case TPM2_ALG_SHA256:
+		return VB2_HASH_SHA256;
+	case TPM2_ALG_SHA384:
+		return VB2_HASH_SHA384;
+	case TPM2_ALG_SHA512:
+		return VB2_HASH_SHA512;
+
+	default:
+		return VB2_HASH_INVALID;
+	}
+}
+
 #endif /* LOGS_H_ */


### PR DESCRIPTION
* PCR-0 and (optionally) PCR-7
* TigerLake and newer
* Commit messages and comments in the code provide more details

Was tested for sanity in QEMU which helped to find bugs, but not on hardware (one attempt resulted in a brick although not necessarily related to the new code which doesn't reset the machine or otherwise prevents boot in any way).

*ref: ncm-1811*