### PR TITLE
Fix RW window for accessing full flash

### DIFF
--- a/payloads/external/edk2/Kconfig.dasharo
+++ b/payloads/external/edk2/Kconfig.dasharo
@@ -4,7 +4,7 @@ config EDK2_REPOSITORY
 	default "https://github.com/Dasharo/edk2"
 
 config EDK2_TAG_OR_REV
-	default "e4dea91cef0af9dbb05e7a407bb18ca18080cbaf"
+	default "22333c9e249641293ce4415e726354f396a0d8d3"
 
 config EDK2_SYSTEM76_EC_LOGGING
 	bool "Enable edk2 logging to System76 EC"

--- a/src/drivers/efi/capsules.c
+++ b/src/drivers/efi/capsules.c
@@ -7,6 +7,7 @@
 #include <cbmem.h>
 #include <console/console.h>
 #include <cpu/x86/pae.h>
+#include <delay.h>
 #include <drivers/efi/efivars.h>
 #include <drivers/efi/capsules.h>
 #include <memrange.h>
@@ -792,8 +793,20 @@ static void enable_capsule_smi(void *unused)
 {
 	uint32_t ret;
 
-	ret = call_smm(APM_CNT_SMMSTORE, SMMSTORE_CMD_USE_FULL_FLASH,
-		       (void*)(uintptr_t)uefi_capsule_count);
+	/* SMI can occasionally be ignored, so retry several times on failure. */
+	uint8_t retries_left = 10;
+	while (1) {
+		ret = call_smm(APM_CNT_SMMSTORE, SMMSTORE_CMD_USE_FULL_FLASH,
+			       (void *)(uintptr_t)uefi_capsule_count);
+		if (ret == SMMSTORE_RET_SUCCESS)
+			break;
+
+		if (retries_left-- == 0)
+			break;
+
+		/* Add a tiny delay before making another try. */
+		udelay(100);
+	}
 
 	printk(BIOS_INFO, "%sabled capsule update SMI handler\n",
 	       ret == SMMSTORE_RET_SUCCESS ? "En" : "Dis");

--- a/src/soc/intel/common/block/fast_spi/mmap_boot.c
+++ b/src/soc/intel/common/block/fast_spi/mmap_boot.c
@@ -22,28 +22,55 @@ enum window_type {
 	/* Number of memory-backed regions for reading flash */
 	TOTAL_MMAP_DECODE_WINDOWS,
 
-	/* An optional extra window for part of the flash before IFD BIOS region */
-	PRE_BIOS_DECODE_WINDOW = TOTAL_MMAP_DECODE_WINDOWS,
-
-	/* Maximum number of decode windows */
+	/*
+	 * Maximum number of decode windows.
+	 *
+	 * There is an optional RW window to cover part of the flash preceding IFD BIOS region,
+	 * so `TOTAL_DECODE_WINDOWS` is `TOTAL_MMAP_DECODE_WINDOWS + 1`.
+	 */
 	TOTAL_DECODE_WINDOWS,
 };
 
+static struct mem_region_device mmap_shadow_devs[TOTAL_MMAP_DECODE_WINDOWS];
+static struct xlate_window mmap_windows[TOTAL_MMAP_DECODE_WINDOWS];
+
+static struct xlate_window rw_window;
+
 static struct xlate_region_device real_dev;
-static struct mem_region_device shadow_devs[TOTAL_MMAP_DECODE_WINDOWS];
 static struct xlate_window real_dev_windows[TOTAL_DECODE_WINDOWS];
+static size_t real_dev_win_count;
+
+static void append_real_dev_window(const struct xlate_window *w)
+{
+	if (real_dev_win_count < ARRAY_SIZE(real_dev_windows))
+		real_dev_windows[real_dev_win_count++] = *w;
+	else
+		printk(BIOS_CRIT, "Fast SPI BUG: no room to add a window, ignoring it\n");
+}
 
 static void initialize_mmap_window(enum window_type type, uintptr_t host_base,
 				   uintptr_t flash_base, size_t size)
 {
-	mem_region_device_ro_init(&shadow_devs[type], (void *)host_base, size);
-	xlate_window_init(&real_dev_windows[type], &shadow_devs[type].rdev,
-			  flash_base, size);
+	mem_region_device_ro_init(&mmap_shadow_devs[type], (void *)host_base, size);
+	xlate_window_init(&mmap_windows[type], &mmap_shadow_devs[type].rdev, flash_base, size);
 	printk(BIOS_INFO, "%s: ",
 		(type == FIXED_DECODE_WINDOW) ?
 		 "Fixed Decode Window" : "Extended Decode Window");
 	printk(BIOS_INFO, "SPI flash base=0x%lx, Host base=0x%lx, Size=0x%zx\n",
 	       flash_base, host_base, size);
+
+	append_real_dev_window(&mmap_windows[type]);
+}
+
+static void initialize_rw_window(uintptr_t flash_base, size_t size)
+{
+	const struct region_device *rw_device = boot_device_rw();
+
+	xlate_window_init(&rw_window, rw_device, flash_base, size);
+	printk(BIOS_INFO, "Fast SPI RW Decode Window: SPI flash base=0x%lx, Size=0x%zx\n",
+	       flash_base, size);
+
+	append_real_dev_window(&rw_window);
 }
 
 /*
@@ -100,8 +127,6 @@ static void bios_mmap_init(void)
 	uintptr_t ext_win_host_base, ext_win_flash_base;
 	size_t fixed_win_size, ext_win_size;
 
-	size_t win_count = 0;
-
 	if (init_done)
 		return;
 
@@ -119,7 +144,6 @@ static void bios_mmap_init(void)
 
 	initialize_mmap_window(FIXED_DECODE_WINDOW, fixed_win_host_base, fixed_win_flash_base,
 			       fixed_win_size);
-	win_count++;
 
 	_Static_assert(CONFIG_EXT_BIOS_WIN_BASE != 0, "Extended BIOS window base cannot be 0!");
 	_Static_assert(CONFIG_EXT_BIOS_WIN_SIZE != 0, "Extended BIOS window size cannot be 0!");
@@ -139,7 +163,6 @@ static void bios_mmap_init(void)
 		ext_win_flash_base = fixed_win_flash_base - ext_win_size;
 		initialize_mmap_window(EXT_BIOS_DECODE_WINDOW, ext_win_host_base,
 				       ext_win_flash_base, ext_win_size);
-		win_count++;
 	}
 
 	/*
@@ -150,17 +173,11 @@ static void bios_mmap_init(void)
 	 * Instead, use RW device as yet another window to allow reading whole flash via
 	 * result of boot_device_ro().
 	 */
-	if (CONFIG(FAST_SPI_FULL_RO_BOOTMEDIA) && bios_start) {
-		const struct region_device *rw_device = boot_device_rw();
-		xlate_window_init(&real_dev_windows[PRE_BIOS_DECODE_WINDOW], rw_device,
-				  0, bios_start);
-		win_count++;
+	if (CONFIG(FAST_SPI_FULL_RO_BOOTMEDIA) && bios_start)
+		initialize_rw_window(0, bios_start);
 
-		printk(BIOS_INFO, "Fast SPI Decode Window: SPI flash base=0x0, Size=0x%zx\n",
-		       bios_start);
-	}
-
-	xlate_region_device_ro_init(&real_dev, win_count, real_dev_windows, CONFIG_ROM_SIZE);
+	xlate_region_device_ro_init(&real_dev, real_dev_win_count, real_dev_windows,
+				    CONFIG_ROM_SIZE);
 
 	init_done = true;
 }
@@ -174,7 +191,7 @@ const struct region_device *boot_device_ro(void)
 
 void fast_spi_get_ext_bios_window(uintptr_t *base, size_t *size)
 {
-	const struct region_device *rd = &shadow_devs[EXT_BIOS_DECODE_WINDOW].rdev;
+	const struct region_device *rd = &mmap_shadow_devs[EXT_BIOS_DECODE_WINDOW].rdev;
 
 	bios_mmap_init();
 
@@ -199,13 +216,13 @@ uint32_t spi_flash_get_mmap_windows(struct flash_mmap_window *table)
 	bios_mmap_init();
 
 	for (i = 0; i < TOTAL_MMAP_DECODE_WINDOWS; i++) {
-		if (region_sz(&real_dev_windows[i].sub_region) == 0)
+		if (region_sz(&mmap_windows[i].sub_region) == 0)
 			continue;
 
 		count++;
-		table->flash_base = region_offset(&real_dev_windows[i].sub_region);
-		table->host_base = (uintptr_t)rdev_mmap_full(&shadow_devs[i].rdev);
-		table->size = region_sz(&real_dev_windows[i].sub_region);
+		table->flash_base = region_offset(&mmap_windows[i].sub_region);
+		table->host_base = (uintptr_t)rdev_mmap_full(&mmap_shadow_devs[i].rdev);
+		table->size = region_sz(&mmap_windows[i].sub_region);
 
 		table++;
 	}

--- a/util/lint/kconfig_lint
+++ b/util/lint/kconfig_lint
@@ -1347,8 +1347,8 @@ sub print_wholeconfig {
 sub check_if_file_referenced {
     my $filename = $File::Find::name;
     if (   ( $filename =~ /Kconfig/ )
-        && ( !$filename =~ /\.orig$/ )
-        && ( !$filename =~ /~$/ )
+        && ( !($filename =~ /\.orig$/) )
+        && ( !($filename =~ /~$/) )
         && ( !exists $loaded_files{$filename} ) )
     {
         show_warning("'$filename' is never referenced");


### PR DESCRIPTION
* Make several attempts to enable full flash access in `enable_capsule_smi()`.  This prevents a situation when capsule update fails right away due to `EFI_UNSUPPORTED` on first attempt to communicate with SMMSTORE.
* Bump EDK to get a related fix there.
* Fix RW window in fast SPI flash code.

This is part of fixing https://github.com/Dasharo/dasharo-issues/issues/1338.

EDK part: https://github.com/Dasharo/edk2/pull/255

*ref: ncm-1850*