### PR TITLE
payloads/edk2/Kconfig.dasharo: bump edk2 revision

### DIFF
--- a/payloads/external/edk2/Kconfig.dasharo
+++ b/payloads/external/edk2/Kconfig.dasharo
@@ -4,7 +4,7 @@ config EDK2_REPOSITORY
 	default "https://github.com/Dasharo/edk2"
 
 config EDK2_TAG_OR_REV
-	default "e9a1d19bfa9fb5d6ef52d1dfd96e544c0f35f248"
+	default "7fc441ce5d12aa72ea66ed5b6b8425e821b4db81"
 
 config EDK2_SYSTEM76_EC_LOGGING
 	bool "Enable edk2 logging to System76 EC"


### PR DESCRIPTION
~Update the testing workflow with the OSFV test suite to prove, that VirtIO drivers are visible in QEMU. Update and install the required tools to set up the test suite with osfv-test-data. Use the edk2 revision with support for building VirtIO drivers.~

~See https://github.com/Dasharo/dasharo-issues/issues/901#issuecomment-3005462400 for context. After https://github.com/Dasharo/edk2/pull/258 is merged, update `CONFIG_EDK2_REPOSITORY` and `CONFIG_EDK2_TAG_OR_REV`. After https://github.com/Dasharo/open-source-firmware-validation/pull/905 is merged, update the `Checkout OSFV repository and submodules` job.~

---

Bump edk2 revision, which ships VirtIO storage drivers for q35 mainboard. [A run that proves, that it builds fine](https://github.com/aronowski/coreboot/actions/runs/16099284577/job/45426275191).