### PR TITLE
mb/protectli/vault_jsl/devicetree.cb: disable wake on USB attach

### DIFF
--- a/src/mainboard/protectli/vault_jsl/devicetree.cb
+++ b/src/mainboard/protectli/vault_jsl/devicetree.cb
@@ -41,8 +41,8 @@ chip soc/intel/jasperlake
 		[5] = USB3_PORT_DEFAULT(OC_SKIP),	// M.2 LTE
 	}"
 
-	register "usb2_wake_enable_bitmap" = "0x0012"
-	register "usb3_wake_enable_bitmap" = "0x0003"
+	register "usb2_wake_enable_bitmap" = "0x0002"
+	register "usb3_wake_enable_bitmap" = "0x0001"
 
 	register "SataSalpSupport" = "1"
 	register "SataPortsEnable[1]" = "1"


### PR DESCRIPTION
Restores v0.9.3 behavior of not waking up instantly after entering S3. It seems that the onboard USB3 hub would wake up the platform if wake on attach/detach is enabled.

Upstream-Status: Pending
Change-Id: I6899689ef6814cf46d4808e96efa7c232877fa3d