### PR TITLE
include/cpu/x86/lapic.h: increment the parked AP count in stop_this_cpu

### DIFF
--- a/src/cpu/x86/mp_init.c
+++ b/src/cpu/x86/mp_init.c
@@ -1055,17 +1055,17 @@ enum cb_err mp_park_aps(void)
 	enum cb_err ret;
 	long duration_msecs;
 
-	stopwatch_init(&sw);
-
 	atomic_set(&parked_ap_count, 0);
 
 	ret = mp_run_on_aps(park_this_cpu, NULL, MP_RUN_ON_ALL_CPUS,
 				1000 * USECS_PER_MSEC);
 
+	stopwatch_init_msecs_expire(&sw, 500);
+
 	while (atomic_read(&parked_ap_count) < global_num_aps) {
-		if ((duration_msecs = stopwatch_duration_msecs(&sw)) > 500) {
-			printk(BIOS_DEBUG, "%s failed, %d / %d CPUs parked after %ld msecs\n",
-				   __func__, atomic_read(&parked_ap_count), global_num_aps, duration_msecs);
+		if (stopwatch_expired(&sw)) {
+			printk(BIOS_DEBUG, "%s failed, %d / %d CPUs parked after 500 msecs\n",
+				   __func__, atomic_read(&parked_ap_count), global_num_aps);
 			return CB_ERR;
 
 		}

--- a/src/include/cpu/x86/lapic.h
+++ b/src/include/cpu/x86/lapic.h
@@ -175,6 +175,7 @@ static __always_inline void lapic_send_ipi_others(uint32_t icrlow)
  */
 static __always_inline void stop_this_cpu(void)
 {
+	atomic_inc(&parked_ap_count);
 	/* Called by an AP when it is ready to halt and wait for a new task */
 	halt();
 }


### PR DESCRIPTION
There is another implementation of stop_this_cpu which https://github.com/Dasharo/coreboot/pull/717 failed to handle correctly, resulting in mp_park_aps hanging indefinitely on platforms which do not select AP_IN_SIPI_WAIT.

Upstream-Status: Pending
Change-Id: I4d9212c2bd845063df145544d675fb735286bc3c