### PR TITLE
CBnT: handle SRTM_AC flag in IBBS and support new way of SACM measurements

### DIFF
--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -200,6 +200,25 @@ static enum cb_err get_ibbs_flags(bool *auth_measure, uint64_t *biosacm_sts_mask
 	return CB_SUCCESS;
 }
 
+static enum cb_err copy_acm_signature(struct obuf *ob)
+{
+	/* Not running any checks on the ACM like TXT code does, it must be correct if we got
+	   here. */
+	size_t acm_len;
+	const struct acm_header_v3 *acm = find_in_fit(FIT_ENTRY_TYPE_SACM, &acm_len);
+	if (acm == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find SACM\n");
+		return CB_ERR;
+	}
+
+	/* Versions v3.0 through v5.4 support CBnT and have this field in the same place. */
+	int err = obuf_write(ob, acm->rsa3072_sig, sizeof(acm->rsa3072_sig));
+	if (err)
+		printk(BIOS_ERR, "CBnT: failed to write ACM signature\n");
+
+	return err ? CB_ERR : CB_SUCCESS;
+}
+
 static enum cb_err fill_pcr0_acm_fields(struct obuf *ob)
 {
 	/* Not running any checks on the ACM like TXT code does, it must be correct if we got
@@ -217,12 +236,7 @@ static enum cb_err fill_pcr0_acm_fields(struct obuf *ob)
 	 */
 	(void)obuf_write_le16(ob, acm->txt_svn);
 
-	/* Versions v3.0 through v5.4 support CBnT and have this field in the same place. */
-	int err = obuf_write(ob, acm->rsa3072_sig, sizeof(acm->rsa3072_sig));
-	if (err)
-		printk(BIOS_ERR, "CBnT: failed to write ACM signature\n");
-
-	return err ? CB_ERR : CB_SUCCESS;
+	return copy_acm_signature(ob);
 }
 
 static enum cb_err skip_signature_key(struct ibuf *ib, uint16_t *key_alg)
@@ -348,7 +362,7 @@ static enum cb_err copy_signature(struct ibuf ib, struct obuf *ob)
 	return CB_SUCCESS;
 }
 
-static enum cb_err fill_pcr0_km_fields(struct obuf *ob)
+static enum cb_err copy_km_signature(struct obuf *ob)
 {
 	size_t km_len;
 	const struct km_header *km = find_in_fit(FIT_ENTRY_TYPE_KM, &km_len);
@@ -445,7 +459,39 @@ static enum cb_err fill_pcr7_km_fields(struct obuf *ob)
 	return CB_SUCCESS;
 }
 
-static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob)
+static enum cb_err copy_ibb_hash(struct obuf *ob, uint16_t tpm2_alg)
+{
+	size_t bpm_len;
+	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
+	if (bpm == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find BPM\n");
+		return CB_ERR;
+	}
+
+	unsigned int i;
+	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
+	const struct hash_struct *ibb_hash = ibbs->digest_list.hashes;
+	for (i = 0; i < ibbs->digest_list.count; ++i) {
+		if (ibb_hash->alg == tpm2_alg)
+			break;
+		ibb_hash = (const void *)&ibb_hash->data[ibb_hash->size];
+	}
+
+	if (i == ibbs->digest_list.count) {
+		printk(BIOS_ERR, "CBnT: failed to find matching IBB digest\n");
+		return CB_ERR;
+	}
+
+	/* IBB.Digest[IBB digest size] */
+	if (obuf_write(ob, ibb_hash->data, ibb_hash->size)) {
+		printk(BIOS_ERR, "CBnT: failed to write IBB digest\n");
+		return CB_ERR;
+	}
+
+	return CB_SUCCESS;
+}
+
+static enum cb_err copy_bpm_signature(struct obuf *ob)
 {
 	size_t bpm_len;
 	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
@@ -464,27 +510,7 @@ static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob)
 		return CB_ERR;
 	}
 
-	unsigned int i;
-	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
-	const struct hash_struct *ibb_hash = ibbs->digest_list.hashes;
-	for (i = 0; i < ibbs->digest_list.count; ++i) {
-		if (ibb_hash->alg == tpm2_alg_from_vb2_hash(tpm_log_alg()))
-			break;
-		ibb_hash = (const void *)&ibb_hash->data[ibb_hash->size];
-	}
-
-	if (i == ibbs->digest_list.count) {
-		printk(BIOS_ERR, "CBnT: failed to find matching IBB signature\n");
-		return CB_ERR;
-	}
-
-	/* IBB.Digest[IBB digest size] */
-	if (obuf_write(ob, ibb_hash->data, ibb_hash->size)) {
-		printk(BIOS_ERR, "CBnT: failed to write IBB signature\n");
-		return CB_ERR;
-	}
-
-	return CB_SUCCESS;
+	return copy_ibb_hash(ob, tpm2_alg_from_vb2_hash(tpm_log_alg()));
 }
 
 /*
@@ -641,7 +667,7 @@ void intel_cbnt_inject_ibg_measurements(void)
 	 * so this buffer should be enough to not run out of space (data measured into PCR-7 is
 	 * smaller).
 	 */
-	char data[sizeof(uint64_t) + sizeof(uint16_t) + 4 * KiB];
+	uint8_t data[sizeof(uint64_t) + sizeof(uint16_t) + 4 * KiB];
 	struct obuf data_ob;
 	obuf_init(&data_ob, data, sizeof(data));
 
@@ -653,35 +679,44 @@ void intel_cbnt_inject_ibg_measurements(void)
 		return;
 	}
 
-	if (fill_pcr0_km_fields(&data_ob) != CB_SUCCESS) {
-		printk(BIOS_ERR, "CBnT: failed to fill KM fields of PCR-0 measurement data\n");
+	if (copy_km_signature(&data_ob) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to copy KM signature for PCR-0 measurement\n");
 		return;
 	}
 
-	if (fill_pcr0_bpm_fields(&data_ob) != CB_SUCCESS) {
-		printk(BIOS_ERR, "CBnT: failed to fill BPM fields of PCR-0 measurement data\n");
+	if (copy_bpm_signature(&data_ob) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to copy BPM signature for PCR-0 measurement\n");
 		return;
 	}
 
-	struct vb2_hash pcr0_hash;
+	struct vb2_hash hash;
 	if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data, obuf_nr_written(&data_ob),
-			       tpm_log_alg(), &pcr0_hash)) {
+			       tpm_log_alg(), &hash)) {
 		printk(BIOS_ERR, "CBnT: failed to hash PCR-0 measurement data\n");
 		return;
 	}
 
+	/* Per BWG this should be logged with EV_S_CRTM_CONTENTS type. */
+	tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 0, hash.algo, hash.raw,
+				vb2_digest_size(hash.algo));
+
 	/* Making and hashing PCR-7 data. */
-	struct vb2_hash pcr7_hash;
 	if (auth_measure) {
 		/* Reuse the first 2 fields of PCR-0 data which are identical in both cases. */
 		obuf_init(&data_ob, data, sizeof(data));
 		(void)obuf_oob_fill(&data_ob, sizeof(uint64_t) + sizeof(uint16_t));
 
-		if (!make_pcr7_hash(&data_ob, &pcr7_hash)) {
+		if (!make_pcr7_hash(&data_ob, &hash)) {
 			printk(BIOS_ERR,
 			       "CBnT: failed to build and hash PCR-7 measurement data\n");
 			return;
 		}
+
+		/* Per BWG this should be logged with EV_EFI_VARIABLE_DRIVER_CONFIG type and
+		   event name should be a Unicode string. */
+		tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 7, hash.algo, hash.raw,
+					vb2_digest_size(hash.algo));
+		printk(BIOS_INFO, "CBnT: reconstructed PCR-7 measurement\n");
 	}
 
 	/*
@@ -689,15 +724,4 @@ void intel_cbnt_inject_ibg_measurements(void)
 	 * the boot anyway as Measured Boot failures generally aren't fatal and incorrect hash
 	 * will be caught later during the boot process.  So not bothering.
 	 */
-
-	/* Per BWG this should be logged with EV_S_CRTM_CONTENTS type. */
-	tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 0, pcr0_hash.algo, pcr0_hash.raw,
-				vb2_digest_size(pcr0_hash.algo));
-	if (auth_measure) {
-		/* Per BWG this should be logged with EV_EFI_VARIABLE_DRIVER_CONFIG type and
-		   event name should be a Unicode string. */
-		tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 7, pcr7_hash.algo,
-					pcr7_hash.raw, vb2_digest_size(pcr7_hash.algo));
-		printk(BIOS_INFO, "CBnT: reconstructed PCR-7 measurement\n");
-	}
 }

--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -90,7 +90,7 @@ struct bpm_ibbs {
 	uint64_t dma_prot_limit1;
 	struct hash_struct post_ibb_hash; /* deprecated since v1.2.0 of CBnT BWG */
 	uint32_t ibb_entry_point;
-	struct bpm_hash_list digest_list; /* each entries is of variable size */
+	struct bpm_hash_list digest_list; /* each entry is of variable size */
 	/* struct bpm_ibbs_bottom bottom; */
 } __packed;
 
@@ -584,14 +584,15 @@ void intel_cbnt_inject_ibg_measurements(void)
 		return;
 	}
 
-	/* cap_pcrs() must have logged that PCRs were capped, nothing else to do on TPM error. */
+	/* cap_pcrs() must have logged that PCRs were capped, nothing else to do on TPM
+	   error. */
 	if (!biosacm_sts.status.tpm_success) {
 		printk(BIOS_ERR, "CBnT: TPM failure detected\n");
 		return;
 	}
 
 	/*
-	 * Making and hashing PCR-7 data.
+	 * Making and hashing PCR-0 data.
 	 *
 	 * Pseudo-code of the data to be measured into PCR-0 for TigerLake and newer (older
 	 * hardware isn't supported yet):

--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -534,6 +534,10 @@ static bool make_pcr7_hash(struct obuf *ob, struct vb2_hash *hash)
 
 int intel_cbnt_get_locality(void)
 {
+	/* Startup locality is always 0 for TPM 1.2. */
+	if (tlcl_get_family() == TPM_1)
+		return 0;
+
 	union cbnt_biosacm_policy biosacm_sts = {
 		.raw = read64p(CBNT_BIOSACM_POLICY_STS),
 	};

--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -26,7 +26,10 @@
 #define BPM_IBBS_FLAG_TOP_SWAP_SUPPORTED    (1 << 4)
 #define BPM_IBBS_FLAG_FORCE_TME             (1 << 5)
 #define BPM_IBBS_FLAG_FORCE_IGN             (1 << 6)
-#define BPM_IBBS_FLAG_SRTM_AC               (1 << 7)
+#define BPM_IBBS_FLAG_SRTM_AC               (1 << 7) /* attestation control */
+
+/* Mask applied to ACM_POLICY_STATUS when BPM_IBBS_FLAG_SRTM_AC is set. */
+#define SRTM_AC_MASK  0x20FFF
 
 /* Bits of `struct km_hash::usage` indicating to which public key the hash corresponds. */
 #define KM_HASH_USAGE_BPM       (1 << 0)
@@ -174,6 +177,27 @@ static const void *find_in_fit(uint8_t type, size_t *size)
 	}
 
 	return addr;
+}
+
+static enum cb_err get_ibbs_flags(bool *auth_measure, uint64_t *biosacm_sts_mask)
+{
+	size_t bpm_len;
+	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
+	if (bpm == NULL) {
+		printk(BIOS_ERR, "CBnT: failed to find BPM\n");
+		return CB_ERR;
+	}
+
+	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
+	*auth_measure = (ibbs->flags & BPM_IBBS_FLAG_AUTH_MEASURE) != 0;
+	*biosacm_sts_mask =
+		(ibbs->flags & BPM_IBBS_FLAG_SRTM_AC) != 0 ? SRTM_AC_MASK : ~(uint64_t)0;
+
+	/* Auth data is measured only for TPM2. */
+	if (*auth_measure && tlcl_get_family() != TPM_2)
+		*auth_measure = false;
+
+	return CB_SUCCESS;
 }
 
 static enum cb_err fill_pcr0_acm_fields(struct obuf *ob)
@@ -421,7 +445,7 @@ static enum cb_err fill_pcr7_km_fields(struct obuf *ob)
 	return CB_SUCCESS;
 }
 
-static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob, bool *auth_measure)
+static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob)
 {
 	size_t bpm_len;
 	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
@@ -440,14 +464,8 @@ static enum cb_err fill_pcr0_bpm_fields(struct obuf *ob, bool *auth_measure)
 		return CB_ERR;
 	}
 
-	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
-	*auth_measure = (ibbs->flags & BPM_IBBS_FLAG_AUTH_MEASURE) != 0;
-
-	/* Auth data is measured only for TPM2. */
-	if (*auth_measure && tlcl_get_family() != TPM_2)
-		*auth_measure = false;
-
 	unsigned int i;
+	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
 	const struct hash_struct *ibb_hash = ibbs->digest_list.hashes;
 	for (i = 0; i < ibbs->digest_list.count; ++i) {
 		if (ibb_hash->alg == tpm2_alg_from_vb2_hash(tpm_log_alg()))
@@ -607,6 +625,13 @@ void intel_cbnt_inject_ibg_measurements(void)
 	 *     } PCR0_DATA;
 	 */
 
+	bool auth_measure;
+	uint64_t biosacm_sts_mask;
+	if (get_ibbs_flags(&auth_measure, &biosacm_sts_mask) != CB_SUCCESS) {
+		printk(BIOS_ERR, "CBnT: failed to obtain IBBS flags from BPM\n");
+		return;
+	}
+
 	/*
 	 * Allow for 4 8192-bit digests in PCR-0 measurements which is an unlikely situation,
 	 * so this buffer should be enough to not run out of space (data measured into PCR-7 is
@@ -617,7 +642,7 @@ void intel_cbnt_inject_ibg_measurements(void)
 	obuf_init(&data_ob, data, sizeof(data));
 
 	/* ACM_POLICY_STATUS (won't run out of space on this one) */
-	(void)obuf_write_le64(&data_ob, biosacm_sts.raw);
+	(void)obuf_write_le64(&data_ob, biosacm_sts.raw & biosacm_sts_mask);
 
 	if (fill_pcr0_acm_fields(&data_ob) != CB_SUCCESS) {
 		printk(BIOS_ERR, "CBnT: failed to fill ACM fields of PCR-0 measurement data\n");
@@ -629,8 +654,7 @@ void intel_cbnt_inject_ibg_measurements(void)
 		return;
 	}
 
-	bool auth_measure;
-	if (fill_pcr0_bpm_fields(&data_ob, &auth_measure) != CB_SUCCESS) {
+	if (fill_pcr0_bpm_fields(&data_ob) != CB_SUCCESS) {
 		printk(BIOS_ERR, "CBnT: failed to fill BPM fields of PCR-0 measurement data\n");
 		return;
 	}

--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -39,6 +39,12 @@
 #define KM_HASH_USAGE_PFR_CPLD  (1 << 4)
 
 /*
+ * SRTM version is an upper-case hex dump of ACM's "Date" (offset 20) and "TXT SVN" (offset 28)
+ * fields as a NUL-terminated UTF16 string.
+ */
+#define SCRTM_VERSION_LENGTH  13
+
+/*
  * Definitions of the structures come from Intel document #575623 CBnT BWG v1.2.5 ("Intel
  * Converged Boot Guard and Intel Trusted Execution Technology (Intel TXT) BIOS Specification").
  *
@@ -179,7 +185,8 @@ static const void *find_in_fit(uint8_t type, size_t *size)
 	return addr;
 }
 
-static enum cb_err get_ibbs_flags(bool *auth_measure, uint64_t *biosacm_sts_mask)
+static enum cb_err get_flags(bool *conventional_measurements, bool *auth_measure,
+			     uint64_t *biosacm_sts_mask)
 {
 	size_t bpm_len;
 	const struct bpm_header *bpm = find_in_fit(FIT_ENTRY_TYPE_BPM, &bpm_len);
@@ -187,6 +194,11 @@ static enum cb_err get_ibbs_flags(bool *auth_measure, uint64_t *biosacm_sts_mask
 		printk(BIOS_ERR, "CBnT: failed to find BPM\n");
 		return CB_ERR;
 	}
+
+	/* Meteor Lake seems to be the first generation with new (more TCG-like) style of
+	   measurements. */
+	*conventional_measurements = !CONFIG(SOC_INTEL_METEORLAKE)
+				  && !CONFIG(SOC_INTEL_PANTHERLAKE_BASE);
 
 	const struct bpm_ibbs *ibbs = (const void *)bpm->se_element;
 	*auth_measure = (ibbs->flags & BPM_IBBS_FLAG_AUTH_MEASURE) != 0;
@@ -613,6 +625,13 @@ static enum cb_err cap_pcrs(union cbnt_biosacm_policy biosacm_sts)
 	return CB_SUCCESS;
 }
 
+static char hex_digit(int nibble)
+{
+	if (nibble < 10)
+		return '0' + nibble;
+	return 'A' + nibble - 10;
+}
+
 void intel_cbnt_inject_ibg_measurements(void)
 {
 	const union cbnt_biosacm_policy biosacm_sts = {
@@ -639,25 +658,11 @@ void intel_cbnt_inject_ibg_measurements(void)
 		return;
 	}
 
-	/*
-	 * Making and hashing PCR-0 data.
-	 *
-	 * Pseudo-code of the data to be measured into PCR-0 for TigerLake and newer (older
-	 * hardware isn't supported yet):
-	 *
-	 *     struct {
-	 *          uint64_t ACM_POLICY_STATUS;
-	 *          uint16_t ACM.Header.SVN;
-	 *          uint8_t  ACM.Signature[ACM signature size];
-	 *          uint8_t  KM.Signature[KM signature size];
-	 *          uint8_t  BPM.Signature[BPM signature size];
-	 *          uint8_t  IBB.Digest[IBB digest size];
-	 *     } PCR0_DATA;
-	 */
-
+	bool conventional_measurements;
 	bool auth_measure;
 	uint64_t biosacm_sts_mask;
-	if (get_ibbs_flags(&auth_measure, &biosacm_sts_mask) != CB_SUCCESS) {
+	if (get_flags(&conventional_measurements, &auth_measure, &biosacm_sts_mask) !=
+	    CB_SUCCESS) {
 		printk(BIOS_ERR, "CBnT: failed to obtain IBBS flags from BPM\n");
 		return;
 	}
@@ -671,52 +676,151 @@ void intel_cbnt_inject_ibg_measurements(void)
 	struct obuf data_ob;
 	obuf_init(&data_ob, data, sizeof(data));
 
-	/* ACM_POLICY_STATUS (won't run out of space on this one) */
-	(void)obuf_write_le64(&data_ob, biosacm_sts.raw & biosacm_sts_mask);
+	if (conventional_measurements) {
+		/*
+		 * Making and hashing PCR-0 data.
+		 *
+		 * Pseudo-code of the data to be measured into PCR-0 for TigerLake and newer
+		 * (older hardware isn't supported yet):
+		 *
+		 *     struct {
+		 *          uint64_t ACM_POLICY_STATUS;
+		 *          uint16_t ACM.Header.SVN;
+		 *          uint8_t  ACM.Signature[ACM signature size];
+		 *          uint8_t  KM.Signature[KM signature size];
+		 *          uint8_t  BPM.Signature[BPM signature size];
+		 *          uint8_t  IBB.Digest[IBB digest size];
+		 *     } PCR0_DATA;
+		 */
 
-	if (fill_pcr0_acm_fields(&data_ob) != CB_SUCCESS) {
-		printk(BIOS_ERR, "CBnT: failed to fill ACM fields of PCR-0 measurement data\n");
-		return;
-	}
+		/* ACM_POLICY_STATUS (won't run out of space on this one) */
+		(void)obuf_write_le64(&data_ob, biosacm_sts.raw & biosacm_sts_mask);
 
-	if (copy_km_signature(&data_ob) != CB_SUCCESS) {
-		printk(BIOS_ERR, "CBnT: failed to copy KM signature for PCR-0 measurement\n");
-		return;
-	}
-
-	if (copy_bpm_signature(&data_ob) != CB_SUCCESS) {
-		printk(BIOS_ERR, "CBnT: failed to copy BPM signature for PCR-0 measurement\n");
-		return;
-	}
-
-	struct vb2_hash hash;
-	if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data, obuf_nr_written(&data_ob),
-			       tpm_log_alg(), &hash)) {
-		printk(BIOS_ERR, "CBnT: failed to hash PCR-0 measurement data\n");
-		return;
-	}
-
-	/* Per BWG this should be logged with EV_S_CRTM_CONTENTS type. */
-	tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 0, hash.algo, hash.raw,
-				vb2_digest_size(hash.algo));
-
-	/* Making and hashing PCR-7 data. */
-	if (auth_measure) {
-		/* Reuse the first 2 fields of PCR-0 data which are identical in both cases. */
-		obuf_init(&data_ob, data, sizeof(data));
-		(void)obuf_oob_fill(&data_ob, sizeof(uint64_t) + sizeof(uint16_t));
-
-		if (!make_pcr7_hash(&data_ob, &hash)) {
+		if (fill_pcr0_acm_fields(&data_ob) != CB_SUCCESS) {
 			printk(BIOS_ERR,
-			       "CBnT: failed to build and hash PCR-7 measurement data\n");
+			       "CBnT: failed to fill ACM fields of PCR-0 measurement data\n");
 			return;
 		}
 
-		/* Per BWG this should be logged with EV_EFI_VARIABLE_DRIVER_CONFIG type and
-		   event name should be a Unicode string. */
-		tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 7, hash.algo, hash.raw,
+		if (copy_km_signature(&data_ob) != CB_SUCCESS) {
+			printk(BIOS_ERR,
+			       "CBnT: failed to copy KM signature for PCR-0 measurement\n");
+			return;
+		}
+
+		if (copy_bpm_signature(&data_ob) != CB_SUCCESS) {
+			printk(BIOS_ERR,
+			       "CBnT: failed to copy BPM signature for PCR-0 measurement\n");
+			return;
+		}
+
+		struct vb2_hash hash;
+		if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data,
+				       obuf_nr_written(&data_ob), tpm_log_alg(), &hash)) {
+			printk(BIOS_ERR, "CBnT: failed to hash PCR-0 measurement data\n");
+			return;
+		}
+
+		/* Per BWG this should be logged with EV_S_CRTM_CONTENTS type. */
+		tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 0, hash.algo, hash.raw,
 					vb2_digest_size(hash.algo));
-		printk(BIOS_INFO, "CBnT: reconstructed PCR-7 measurement\n");
+
+		/* Optionally making and hashing PCR-7 data (not supported since MTL). */
+		if (auth_measure) {
+			/* Reuse the first 2 fields of PCR-0 data which are identical in both
+			   cases. */
+			obuf_init(&data_ob, data, sizeof(data));
+			(void)obuf_oob_fill(&data_ob, sizeof(uint64_t) + sizeof(uint16_t));
+
+			if (!make_pcr7_hash(&data_ob, &hash)) {
+				printk(BIOS_ERR,
+				       "CBnT: failed to build and hash PCR-7 measurement data\n");
+				return;
+			}
+
+			/* Per BWG this should be logged with EV_EFI_VARIABLE_DRIVER_CONFIG type
+			   and event name should be a Unicode string. */
+			tpm_log_add_table_entry(CBNT_EVENT_LOG_MESSAGE, 7, hash.algo, hash.raw,
+						vb2_digest_size(hash.algo));
+			printk(BIOS_INFO, "CBnT: reconstructed PCR-7 measurement\n");
+		}
+
+	} else {
+		size_t acm_len;
+		const struct acm_header_v3 *acm = find_in_fit(FIT_ENTRY_TYPE_SACM, &acm_len);
+		if (acm == NULL) {
+			printk(BIOS_ERR, "CBnT: failed to find SACM\n");
+			return;
+		}
+
+		uint8_t crtm_version[6];
+		memcpy(&crtm_version[0], &acm->date, 4);
+		memcpy(&crtm_version[4], &acm->txt_svn, 2);
+
+		char crtm_version_str[SCRTM_VERSION_LENGTH] = {0};
+		uint16_t crtm_version_utf16[SCRTM_VERSION_LENGTH] = {0};
+		for (int i = 0; i < sizeof(crtm_version); ++i) {
+			crtm_version_str[i*2 + 0] = hex_digit(crtm_version[i] >> 4);
+			crtm_version_str[i*2 + 1] = hex_digit(crtm_version[i] & 0xf);
+
+			crtm_version_utf16[i*2 + 0] = crtm_version_str[i*2 + 0];
+			crtm_version_utf16[i*2 + 1] = crtm_version_str[i*2 + 1];
+		}
+
+		struct vb2_hash hash;
+		if (vb2_hash_calculate(vboot_hwcrypto_allowed(), crtm_version_utf16,
+				       sizeof(crtm_version_utf16), tpm_log_alg(), &hash)) {
+			printk(BIOS_ERR, "CBnT: failed to hash CRTM version\n");
+			return;
+		}
+		/* Per BWG this should be logged with EV_S_CRTM_VERSION type. */
+		tpm_log_add_table_entry(crtm_version_str, 0, hash.algo, hash.raw,
+					vb2_digest_size(hash.algo));
+
+		if (copy_ibb_hash(&data_ob, tpm2_alg_from_vb2_hash(tpm_log_alg())) !=
+		    CB_SUCCESS) {
+			printk(BIOS_ERR, "CBnT: failed to obtain IBB digest\n");
+			return;
+		}
+		/* Per BWG this should be logged with EV_POST_CODE type. */
+		tpm_log_add_table_entry("Boot Guard Measured IBB", 0, tpm_log_alg(), data,
+					obuf_nr_written(&data_ob));
+
+		/*
+		 * struct {
+		 *      uint64_t ACM_POLICY_STATUS;
+		 *      uint8_t  KM.Signature[KM signature size];
+		 *      uint8_t  BPM.Signature[BPM signature size];
+		 * } POLICY_DATA;
+		 */
+		obuf_init(&data_ob, data, sizeof(data));
+
+		/* ACM_POLICY_STATUS (won't run out of space on this one) */
+		(void)obuf_write_le64(&data_ob, biosacm_sts.raw & biosacm_sts_mask);
+		if (copy_acm_signature(&data_ob) != CB_SUCCESS) {
+			printk(BIOS_ERR, "CBnT: failed to copy ACM signature\n");
+			return;
+		}
+		if (copy_km_signature(&data_ob) != CB_SUCCESS) {
+			printk(BIOS_ERR, "CBnT: failed to copy KM signature\n");
+			return;
+		}
+		if (copy_bpm_signature(&data_ob) != CB_SUCCESS) {
+			printk(BIOS_ERR,
+			       "CBnT: failed to copy BPM signature for PCR-0 measurement\n");
+			return;
+		}
+		if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data,
+				       obuf_nr_written(&data_ob), tpm_log_alg(), &hash)) {
+			printk(BIOS_ERR, "CBnT: failed to hash POLICY_DATA\n");
+			return;
+		}
+		/* Per BWG this should be logged with EV_POST_CODE type. */
+		if (tpm_extend_pcr(0, hash.algo, hash.raw, vb2_digest_size(hash.algo),
+				   "BIOS Measured Boot Guard Policy") != TPM_SUCCESS) {
+			printk(BIOS_ERR, "CBnT: failed to extend POLICY_DATA\n");
+			return;
+		}
 	}
 
 	/*


### PR DESCRIPTION
When SRTM_AC flag set, the value of ACM_POLICY_STATUS register is masked to exclude dynamically detectable values making measurements more reliable.

Starting with MTL, SACM performs 2 PCR-0 measurements and doesn't do PCR-7 measurement.  There is also a new POLICY_DATA PCR-0 measurement carried out by the BIOS with information from the pre-MTL way of doing things.

*ref: ncm-1937*