### PR TITLE
TPM fixes for Jasper Lake

### DIFF
--- a/payloads/external/edk2/Kconfig.dasharo
+++ b/payloads/external/edk2/Kconfig.dasharo
@@ -4,7 +4,7 @@ config EDK2_REPOSITORY
 	default "https://github.com/Dasharo/edk2"
 
 config EDK2_TAG_OR_REV
-	default "e4616bfb0b40b6ac710fdb2e20110de874cc17c6"
+	default "f363c3ad2b8492f8f357a1c3578191f52395c480"
 
 config EDK2_SYSTEM76_EC_LOGGING
 	bool "Enable edk2 logging to System76 EC"

--- a/src/drivers/crb/tis.c
+++ b/src/drivers/crb/tis.c
@@ -105,6 +105,12 @@ static void crb_tpm_fill_ssdt(const struct device *dev)
 	acpigen_pop_len(); /* Device */
 }
 
+static void crb_tpm_read_resources(struct device *dev)
+{
+	/* Static 5K memory region specified in Kconfig */
+	mmio_range(dev, 0, TPM_CRB_BASE_ADDRESS, 0x5000);
+}
+
 static const char *crb_tpm_acpi_name(const struct device *dev)
 {
 	return "TPM";
@@ -194,7 +200,7 @@ static int smbios_write_type43_tpm(struct device *dev, int *handle, unsigned lon
 #endif
 
 static struct device_operations __maybe_unused crb_ops = {
-	.read_resources = noop_read_resources,
+	.read_resources = crb_tpm_read_resources,
 	.set_resources = noop_set_resources,
 #if CONFIG(HAVE_ACPI_TABLES)
 	.acpi_name = crb_tpm_acpi_name,


### PR DESCRIPTION
* Reserve TPM's MMIO range (wasn't causing problems, but it should be reserved).
* Bump EDK for a workaround there.

EDK PR: https://github.com/Dasharo/edk2/pull/273
*ref: prot-1876*