### PR TITLE
soc/intel/alderlake/fsp_params.c: Fix CPU features programming on S3 …

### DIFF
--- a/payloads/external/edk2/Kconfig.dasharo
+++ b/payloads/external/edk2/Kconfig.dasharo
@@ -4,7 +4,7 @@ config EDK2_REPOSITORY
 	default "https://github.com/Dasharo/edk2"
 
 config EDK2_TAG_OR_REV
-	default "f363c3ad2b8492f8f357a1c3578191f52395c480"
+	default "91a7a092361befde7ddf2cd9915828852aff1195"
 
 config EDK2_SYSTEM76_EC_LOGGING
 	bool "Enable edk2 logging to System76 EC"

--- a/src/soc/intel/alderlake/fsp_params.c
+++ b/src/soc/intel/alderlake/fsp_params.c
@@ -717,6 +717,11 @@ static void fill_fsps_cpu_params(FSP_S_CONFIG *s_cfg,
 		fill_fsps_microcode_params(s_cfg, config);
 	else
 		s_cfg->SkipMpInit = !CONFIG(USE_INTEL_FSP_MP_INIT);
+
+#if CONFIG(FSP_TYPE_IOT) && CONFIG(HAVE_ACPI_RESUME)
+	if (!s_cfg->SkipMpInit)
+		s_cfg->CpuFeaturesInitOnS3ResumeOverride = 1;
+#endif
 }
 
 static void fill_fsps_igd_params(FSP_S_CONFIG *s_cfg,


### PR DESCRIPTION
…resume

Some FSPs do not program CPU features on S3 resume. Most likely they were built with gUefiCpuPkgTokenSpaceGuid.PcdCpuFeaturesInitOnS3Resume set to FALSE by default. It was later fixed to be TRUE by default, but the FSPs did not pull this change. However, IoT FSPs provide an UPD to override this PCD. Use it to ensure the CPU features are programmed on S3 resume if FSP MP init is used and S3 resume is supported.

TEST=Perform suspend/resume test with FWTS on ODROID-H4.

Upstream-Status: Pending