### PR TITLE
Protectli Vault JSL: don't report LANs via SMBIOS Type 41

### DIFF
--- a/src/include/smbios.h
+++ b/src/include/smbios.h
@@ -1204,7 +1204,7 @@ typedef enum {
 	SMBIOS_DEVICE_TYPE_UFS,
 } smbios_onboard_device_type;
 
-#define SMBIOS_DEVICE_TYPE_COUNT 10
+#define SMBIOS_DEVICE_TYPE_COUNT 16
 
 struct smbios_type41 {
 	struct smbios_header header;

--- a/src/mainboard/protectli/vault_jsl/mainboard.c
+++ b/src/mainboard/protectli/vault_jsl/mainboard.c
@@ -2,7 +2,6 @@
 
 #include <arch/mmio.h>
 #include <device/device.h>
-#include <device/pci_ids.h>
 #include <fmap.h>
 #include <gpio.h>
 #include <pc80/i8254.h>
@@ -10,7 +9,6 @@
 #include <soc/gpio.h>
 #include <soc/intel/common/reset.h>
 #include <soc/iomap.h>
-#include <soc/pci_devs.h>
 #include <soc/ramstage.h>
 
 #define FSP_PCH_PCIE_ASPM_L1 2
@@ -136,71 +134,6 @@ const char *smbios_chassis_version(void)
 	return "1.2";
 }
 
-static int smbios_type41_write_ethernet(struct device *parent, int *handle,
-					unsigned long *current)
-{
-	struct device *eth;
-	static u8 instance = 0;
-
-	if (!parent || !parent->enabled)
-		return 0;
-
-	eth = pcidev_path_behind(parent->downstream, PCI_DEVFN(0, 0));
-	if (!eth || !eth->enabled)
-		return 0;
-
-	/* Only i226 Ehternet Controller */
-	if (eth->vendor != PCI_VID_INTEL || eth->device != 0x125c)
-		return 0;
-
-	return smbios_write_type41(
-		current, handle,
-		"Onboard - Ethernet",		/* name */
-		instance++,			/* instance */
-		0,				/* segment */
-		eth->upstream->secondary,		/* bus */
-		PCI_SLOT(eth->path.pci.devfn),	/* device */
-		PCI_FUNC(eth->path.pci.devfn),	/* function */
-		SMBIOS_DEVICE_TYPE_ETHERNET);	/* device type */
-}
-
-static int smbios_type41_write_ethernet_behind_switch(struct device *root_port, int *handle,
-						      unsigned long *current)
-{
-	struct device *switch_dev;
-	struct device *child;
-	int len = 0;
-
-	if (!root_port || !root_port->enabled)
-		return 0;
-
-	switch_dev = pcidev_path_behind(root_port->downstream, PCI_DEVFN(0, 0));
-	if (!switch_dev || !switch_dev->enabled)
-		return 0;
-
-	/* Only ASMedia switch */
-	if (switch_dev->vendor != 0x1b21 || switch_dev->device != 0x2806)
-		return 0;
-
-	/* After upstream port there is also one downstream port */
-	switch_dev = pcidev_path_behind(switch_dev->downstream, PCI_DEVFN(0, 0));
-	if (!switch_dev || !switch_dev->enabled)
-		return 0;
-
-	/* Only ASMedia switch */
-	if (switch_dev->vendor != 0x1b21 || switch_dev->device != 0x2806)
-		return 0;
-
-	/* Loop through all downstream ports of the switch */
-	for (child = switch_dev->upstream->children; child; child = child->sibling) {
-		printk(BIOS_DEBUG, "Switch DS port %s [%04x:%04x]\n",
-			dev_path(child), child->vendor, child->device);
-		len += smbios_type41_write_ethernet(child, handle, current);
-	}
-
-	return len;
-}
-
 static int mainboard_smbios_data(struct device *dev, int *handle,
 				 unsigned long *current)
 {
@@ -235,16 +168,6 @@ static int mainboard_smbios_data(struct device *dev, int *handle,
 		PCH_DEV_SLOT_STORAGE,		/* device */
 		0,				/* function */
 		SMBIOS_DEVICE_TYPE_OTHER);	/* device type */
-
-	if (CONFIG(BOARD_PROTECTLI_V1410)) {
-		len += smbios_type41_write_ethernet(PCH_DEV_PCIE1, handle, current);
-		len += smbios_type41_write_ethernet(PCH_DEV_PCIE2, handle, current);
-	} else if (CONFIG(BOARD_PROTECTLI_V1610)) {
-		len += smbios_type41_write_ethernet_behind_switch(PCH_DEV_PCIE1, handle,
-								  current);
-	}
-	len += smbios_type41_write_ethernet(PCH_DEV_PCIE6, handle, current);
-	len += smbios_type41_write_ethernet(PCH_DEV_PCIE7, handle, current);
 
 	return len;
 }


### PR DESCRIPTION
This partially undoes https://github.com/Dasharo/coreboot/pull/708.  My guess is that this is motivated by AMI not publishing these records.

There is also an upstreamable  fix for a constant which wasn't updated in time in upstream.  It shouldn't be used for these devices, but maybe it will help with some others.

*ref: prot-1905*