### PR TITLE
edk2/Makefile: Add -v for compiler errors in the output

### DIFF
--- a/payloads/external/edk2/Makefile
+++ b/payloads/external/edk2/Makefile
@@ -43,6 +43,9 @@ endif
 
 BUILD_STR += -D BUILD_ARCH=X64
 
+# Enable compiler errors printing from EDK2
+BUILD_STR += -v
+
 #
 # EDK II (edk2/master) has the following build options relevant to coreboot:
 #


### PR DESCRIPTION
I find it no fun to try and fix the ways of my coreboot+EDK2 inexperienced self without any errors being printed from EDK2 during the build.