### PR TITLE
.github/workflows/build.yml: fix build_novacustom dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,6 @@ jobs:
           token: ${{ secrets.NCM_BLOBS_TOKEN }}
       - name: Build Dasharo
         run: |
-          mv ${{ matrix.vendor }}_${{ matrix.model }}_ec.rom ec.rom
           ./build.sh ${{ matrix.model }}
       - name: Copy default testing keys for capsules
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,7 +455,7 @@ jobs:
         model: [ vp46xx ]
   deploy_novacustom_adl:
     if: startsWith(github.ref, 'refs/tags/novacustom') && contains(github.ref, 'adl')
-    needs: build_novacustom
+    needs: build_novacustom_laptop
     uses: ./.github/workflows/deploy-template.yml
     with:
       platform: novacustom
@@ -469,7 +469,7 @@ jobs:
         model: [ nv4x_adl, ns5x_adl ]
   deploy_novacustom_tgl:
     if: startsWith(github.ref, 'refs/tags/novacustom') && contains(github.ref, 'tgl')
-    needs: build_novacustom
+    needs: build_novacustom_laptop
     uses: ./.github/workflows/deploy-template.yml
     with:
       platform: novacustom


### PR DESCRIPTION
Fixes the dependency on deprecated build_novacustom job, replacing it with the new build_novacustom_laptop

Upstream-Status: Inappropriate [Dasharo downstream]