### PR TITLE
mb/novacustom/mtl-h/variants/dgpu/overridetree.cb: Fix dGPU not comin…

### DIFF
--- a/src/mainboard/novacustom/mtl-h/variants/dgpu/overridetree.cb
+++ b/src/mainboard/novacustom/mtl-h/variants/dgpu/overridetree.cb
@@ -17,7 +17,7 @@ chip soc/intel/meteorlake
 			register "pcie_rp[PCH_RP(12)]" = "{
 				.clk_src = 6,
 				.clk_req = 6,
-				.flags = PCIE_RP_LTR | PCIE_RP_HOTPLUG,
+				.flags = PCIE_RP_LTR | PCIE_RP_AER | PCIE_RP_CLK_REQ_DETECT,
 			}"
 			device pci 00.0 on
 				subsystemid 0x1558 0xa761


### PR DESCRIPTION
…g up after suspend

Fix the root port flags by bringing back the values they were at in release v0.9.1 where suspend worked. This fixes issue where the dGPU would not come back after suspend [1]

[1]: https://github.com/Dasharo/dasharo-issues/issues/1593

*ref: ncm-2010*