### PR TITLE
configs/config.novacustom_v5*: unset boot resolution, set setup menu …

### DIFF
--- a/configs/config.novacustom_v540tnx
+++ b/configs/config.novacustom_v540tnx
@@ -61,7 +61,7 @@ CONFIG_EDK2_SERIAL_SUPPORT=y
 CONFIG_EDK2_FTDI_USB_UART_SUPPORT=y
 CONFIG_EDK2_GOP_FILE="3rdparty/dasharo-blobs/novacustom/v5x0tu/IntelGopDriver.efi"
 CONFIG_EDK2_USE_LAPTOP_LID_LIB=y
-CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution=1080"
+CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution=1080"
 CONFIG_BUILD_IPXE=y
 CONFIG_IPXE_ADD_SCRIPT=y
 CONFIG_IPXE_SCRIPT="3rdparty/dasharo-blobs/dasharo/dasharo.ipxe"

--- a/configs/config.novacustom_v540tu
+++ b/configs/config.novacustom_v540tu
@@ -62,7 +62,7 @@ CONFIG_EDK2_SERIAL_SUPPORT=y
 CONFIG_EDK2_FTDI_USB_UART_SUPPORT=y
 CONFIG_EDK2_GOP_FILE="3rdparty/dasharo-blobs/novacustom/v5x0tu/IntelGopDriver.efi"
 CONFIG_EDK2_USE_LAPTOP_LID_LIB=y
-CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution=1080"
+CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution=1080"
 CONFIG_BUILD_IPXE=y
 CONFIG_IPXE_ADD_SCRIPT=y
 CONFIG_IPXE_SCRIPT="3rdparty/dasharo-blobs/dasharo/dasharo.ipxe"

--- a/configs/config.novacustom_v560tnx
+++ b/configs/config.novacustom_v560tnx
@@ -61,7 +61,7 @@ CONFIG_EDK2_SERIAL_SUPPORT=y
 CONFIG_EDK2_FTDI_USB_UART_SUPPORT=y
 CONFIG_EDK2_GOP_FILE="3rdparty/dasharo-blobs/novacustom/v5x0tu/IntelGopDriver.efi"
 CONFIG_EDK2_USE_LAPTOP_LID_LIB=y
-CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution=1080"
+CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution=1080"
 CONFIG_BUILD_IPXE=y
 CONFIG_IPXE_ADD_SCRIPT=y
 CONFIG_IPXE_SCRIPT="3rdparty/dasharo-blobs/dasharo/dasharo.ipxe"

--- a/configs/config.novacustom_v560tu
+++ b/configs/config.novacustom_v560tu
@@ -62,7 +62,7 @@ CONFIG_EDK2_SERIAL_SUPPORT=y
 CONFIG_EDK2_FTDI_USB_UART_SUPPORT=y
 CONFIG_EDK2_GOP_FILE="3rdparty/dasharo-blobs/novacustom/v5x0tu/IntelGopDriver.efi"
 CONFIG_EDK2_USE_LAPTOP_LID_LIB=y
-CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution=1080"
+CONFIG_EDK2_CUSTOM_BUILD_PARAMS="--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution=1920 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution=1080"
 CONFIG_BUILD_IPXE=y
 CONFIG_IPXE_ADD_SCRIPT=y
 CONFIG_IPXE_SCRIPT="3rdparty/dasharo-blobs/dasharo/dasharo.ipxe"


### PR DESCRIPTION
…resolution

This change makes it so that the boot logo is shown in native resolution and correct aspect ratio, while the setup menu is scaled to 1920x1080 which is bigger and sligtly vertically stretched.

Upstream-Status: Inappropriate [Dasharo downstream]
Change-Id: I897bd00fb01414b5ea7e4c3668e54f0eb4d8813d