### PR TITLE
drivers/pc80/tpm/tis.c: fix TPM ACPI device path again

### DIFF
--- a/src/drivers/pc80/tpm/tis.c
+++ b/src/drivers/pc80/tpm/tis.c
@@ -807,7 +807,7 @@ static void lpc_tpm_set_resources(struct device *dev)
 static void lpc_tpm_fill_ssdt(const struct device *dev)
 {
 	const struct device *domain = dev_get_domain(dev);
-	const char *path = acpi_device_scope(domain);
+	const char *path = acpi_device_path(domain);
 
 	/* Device */
 	acpigen_write_scope(path);


### PR DESCRIPTION
The path should be equal to the path of the ACPI SOC domain, not to its scope. acpi_device_path evaluates to SB.PCI0 on single domain SoCs and SB on multi-domain SoCs like Xeon SPR.

TEST=Boot Windows 11 on NovaCustom V540TU and confirm that TPM works.

Upstream-Status: Pending
Change-Id: I0b61dbccbb5472b498d91972be90cbd297dacfce