### PR TITLE
mb/novacustom/mtl-h: Add per-variant HDA subsystem IDs

### DIFF
--- a/src/mainboard/novacustom/mtl-h/devicetree.cb
+++ b/src/mainboard/novacustom/mtl-h/devicetree.cb
@@ -260,7 +260,6 @@ chip soc/intel/meteorlake
 			end
 		end
 		device ref hda on
-			subsystemid 0x1558 0xa763
 			register "pch_hda_audio_link_hda_enable" = "1"
 			register "pch_hda_sdi_enable[0]" = "1"
 			register "pch_hda_dsp_enable" = "1"

--- a/src/mainboard/novacustom/mtl-h/variants/dgpu/overridetree.cb
+++ b/src/mainboard/novacustom/mtl-h/variants/dgpu/overridetree.cb
@@ -71,5 +71,8 @@ chip soc/intel/meteorlake
 				device generic 0 on end
 			end
 		end
+		device ref hda on
+			subsystemid 0x1558 0xa763
+		end
 	end
 end

--- a/src/mainboard/novacustom/mtl-h/variants/igpu/overridetree.cb
+++ b/src/mainboard/novacustom/mtl-h/variants/igpu/overridetree.cb
@@ -46,6 +46,9 @@ chip soc/intel/meteorlake
 			}"
 			register "pcie_clk_config_flag[2]" = "PCIE_CLK_LAN"
 		end
+		device ref hda on
+			subsystemid 0x1558 0xa743
+		end
 		device ref gbe on end
 	end
 end


### PR DESCRIPTION
Change-Id: I8e3a235bf074fc38d1beef5bc6b0ff92636471f7

TEST=Boot to Windows 11 on V540TU and verify that audio jack works 