### PR TITLE
msi: use `intel-microcode` instead of `dasharo-blobs`

### DIFF
--- a/src/soc/intel/alderlake/Makefile.mk
+++ b/src/soc/intel/alderlake/Makefile.mk
@@ -77,7 +77,13 @@ CPPFLAGS_common += -I$(src)/vendorcode/intel/fsp/fsp2_0/iot/raptorlake_s
 endif
 
 ifeq ($(CONFIG_SOC_INTEL_ALDERLAKE_PCH_S),y)
-cpu_microcode_bins += 3rdparty/dasharo-blobs/msi/ms7e06/microcode.bin
+# 06-97-00, 06-97-01, 06-97-04 are ADL-S Engineering Samples
+# 06-97-02 are ADL-S/HX Quality Samples but also ADL-HX Engineering Samples
+# 06-b7-00 are RPL-S Engineering Samples
+# ADL-S/HX C0/H0 and RPL-S C0/H0
+cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-97-05
+# RPL-S/HX B0
+cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-b7-01
 else ifeq ($(CONFIG_SOC_INTEL_ALDERLAKE_PCH_N),y)
 cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-be-00
 else


### PR DESCRIPTION
Some boards (like the MSI boards) have not been getting microcode from the `intel-microcode` sub-module, instead being hard coded to `dasharo-blobs`, which is out of date.

The PR reverts the commit pinning it to `dasharo-blobs`, as well as bumping the `intel-microcode` sub-module to it's latest release.