### PR TITLE
Btg capsule check

### DIFF
--- a/payloads/external/edk2/Kconfig.dasharo
+++ b/payloads/external/edk2/Kconfig.dasharo
@@ -4,7 +4,7 @@ config EDK2_REPOSITORY
 	default "https://github.com/Dasharo/edk2"
 
 config EDK2_TAG_OR_REV
-	default "3bde471c32b784c91b814f98c070097ff4945231"
+	default "de7e555a0786ee4ebac0b92d867fca8f69c9696d"
 
 config EDK2_SYSTEM76_EC_LOGGING
 	bool "Enable edk2 logging to System76 EC"

--- a/src/include/smbios.h
+++ b/src/include/smbios.h
@@ -277,6 +277,7 @@ typedef enum {
 	SMBIOS_PORT_CONNECTOR_INFORMATION = 8,
 	SMBIOS_SYSTEM_SLOTS = 9,
 	SMBIOS_OEM_STRINGS = 11,
+	SMBIOS_GROUP_ASSOCIATIONS = 14,
 	SMBIOS_EVENT_LOG = 15,
 	SMBIOS_PHYS_MEMORY_ARRAY = 16,
 	SMBIOS_MEMORY_DEVICE = 17,
@@ -958,6 +959,14 @@ struct smbios_type9 {
 struct smbios_type11 {
 	struct smbios_header header;
 	u8 count;
+	u8 eos[2];
+} __packed;
+
+struct smbios_type14 {
+	struct smbios_header header;
+	u8 group_name;
+	u8 item_type;
+	u16 item_handle;
 	u8 eos[2];
 } __packed;
 

--- a/src/mainboard/novacustom/mtl-h/ramstage.c
+++ b/src/mainboard/novacustom/mtl-h/ramstage.c
@@ -6,6 +6,7 @@
 #include <ec/dasharo/ec/acpi.h>
 #include <fmap.h>
 #include <gpio.h>
+#include <intelblocks/cse.h>
 #include <lib.h>
 #include <mainboard/variants.h>
 #include <security/vboot/vboot_common.h>
@@ -210,12 +211,21 @@ static void mainboard_smbios_strings(struct device *dev, struct smbios_type11 *t
 	}
 
 }
+static int mainboard_smbios_data(struct device *dev, int *handle, unsigned long *current)
+{
+	int len = 0;
+
+	len += cse_write_smbios_type14(handle, current);
+
+	return len;
+}
 #endif
 
 
 static void mainboard_enable(struct device *dev)
 {
 #if CONFIG(GENERATE_SMBIOS_TABLES)
+	dev->ops->get_smbios_data = mainboard_smbios_data;
 	dev->ops->get_smbios_strings = mainboard_smbios_strings;
 #endif
 }

--- a/src/soc/intel/apollolake/Kconfig
+++ b/src/soc/intel/apollolake/Kconfig
@@ -128,6 +128,10 @@ config MAX_HECI_DEVICES
 	int
 	default 3
 
+config MAX_MEI_DEVICES
+	int
+	default 3
+
 config MAX_CPUS
 	int
 	default 4

--- a/src/soc/intel/apollolake/heci.c
+++ b/src/soc/intel/apollolake/heci.c
@@ -5,6 +5,7 @@
 #include <device/pci_ops.h>
 #include <soc/heci.h>
 #include <soc/pci_devs.h>
+#include <intelblocks/cse.h>
 
 uint32_t heci_fw_sts(void)
 {
@@ -19,4 +20,18 @@ bool heci_cse_normal(void)
 bool heci_cse_done(void)
 {
 	return (!!(heci_fw_sts() & MASK_SEC_FIRMWARE_COMPLETE));
+}
+
+unsigned int soc_get_heci_dev(unsigned int heci_idx)
+{
+	if (heci_idx > 2)
+		return 0;
+
+	static const unsigned int heci_devs[] = {
+		PCH_DEVFN_CSE,
+		PCH_DEVFN_CSE_2,
+		PCH_DEVFN_CSE_3,
+	};
+
+	return heci_devs[heci_idx];
 }

--- a/src/soc/intel/apollolake/include/soc/pci_devs.h
+++ b/src/soc/intel/apollolake/include/soc/pci_devs.h
@@ -65,7 +65,11 @@
 
 #define PCH_DEV_SLOT_CSE	0x0f
 #define  PCH_DEVFN_CSE		_PCH_DEVFN(CSE, 0)
+#define  PCH_DEVFN_CSE_2	_PCH_DEVFN(CSE, 1)
+#define  PCH_DEVFN_CSE_3	_PCH_DEVFN(CSE, 2)
 #define  PCH_DEV_CSE		_PCH_DEV(CSE, 0)
+#define  PCH_DEV_CSE_2		_PCH_DEV(CSE, 1)
+#define  PCH_DEV_CSE_3		_PCH_DEV(CSE, 2)
 
 #define PCH_DEV_SLOT_ISH	0x11
 #define  PCH_DEVFN_ISH		_PCH_DEVFN(ISH, 0)

--- a/src/soc/intel/common/block/cse/Kconfig
+++ b/src/soc/intel/common/block/cse/Kconfig
@@ -13,6 +13,10 @@ config MAX_HECI_DEVICES
 	int
 	default 6
 
+config MAX_MEI_DEVICES
+	int
+	default 4
+
 config SOC_INTEL_COMMON_BLOCK_CSE
 	bool
 	default n

--- a/src/soc/intel/common/block/cse/cse.c
+++ b/src/soc/intel/common/block/cse/cse.c
@@ -76,6 +76,21 @@
 #define MEI_HDR_CSE_ADDR_START	0
 #define MEI_HDR_CSE_ADDR	(((1 << 8) - 1) << MEI_HDR_CSE_ADDR_START)
 
+__weak unsigned int soc_get_heci_dev(unsigned int heci_idx)
+{
+	if (heci_idx > 3)
+		return 0;
+
+	const unsigned int heci_devs[] = {
+		PCI_DEVFN(0x16, 0),
+		PCI_DEVFN(0x16, 1),
+		PCI_DEVFN(0x16, 4),
+		PCI_DEVFN(0x16, 5)
+	};
+
+	return heci_devs[heci_idx];
+}
+
 /* Get HECI BAR 0 from PCI configuration space */
 static uintptr_t get_cse_bar(pci_devfn_t dev)
 {
@@ -1600,6 +1615,96 @@ static void cse_final(struct device *dev)
 	if (!CONFIG(USE_FSP_NOTIFY_PHASE_END_OF_FIRMWARE))
 		cse_final_end_of_firmware();
 }
+#if CONFIG(GENERATE_SMBIOS_TABLES)
+
+struct fwsts_record {
+	u8 heci_name;
+	u32 reg[6];
+} __packed;
+
+struct fwsts_smbios_table {
+	struct smbios_header header;
+	u8 version;
+	u8 count;
+	struct fwsts_record record[CONFIG_MAX_MEI_DEVICES];
+	u8 eos[2];
+} __packed;
+
+static struct fwsts_record fwsts_cache[CONFIG_MAX_MEI_DEVICES] = { 0 };
+
+static void fill_cse_fwsts(struct fwsts_record *rec, int idx)
+{
+	unsigned int heci_devfn = soc_get_heci_dev(idx);
+	pci_devfn_t heci;
+
+	if (heci_devfn == 0)
+		return;
+
+	heci = PCI_DEV(0, PCI_SLOT(heci_devfn), PCI_FUNC(heci_devfn));
+
+	if (pci_read_config16(heci, PCI_VENDOR_ID) != 0xffff &&
+	    pci_read_config16(heci, PCI_VENDOR_ID) != 0x0000) {
+		rec->reg[0] = pci_read_config32(heci, PCI_ME_HFSTS1);
+		rec->reg[1] = pci_read_config32(heci, PCI_ME_HFSTS2);
+		rec->reg[2] = pci_read_config32(heci, PCI_ME_HFSTS3);
+		rec->reg[3] = pci_read_config32(heci, PCI_ME_HFSTS4);
+		rec->reg[4] = pci_read_config32(heci, PCI_ME_HFSTS5);
+		rec->reg[5] = pci_read_config32(heci, PCI_ME_HFSTS6);
+	} else {
+		rec->reg[0] = 0xffffffff;
+		rec->reg[1] = 0xffffffff;
+		rec->reg[2] = 0xffffffff;
+		rec->reg[3] = 0xffffffff;
+		rec->reg[4] = 0xffffffff;
+		rec->reg[5] = 0xffffffff;
+		printk(BIOS_WARNING, "HECI: CSE device %02x.%01x is hidden\n",
+		       PCI_SLOT(heci_devfn), PCI_FUNC(heci_devfn));
+	}
+}
+
+static void cache_cse_fwsts(void *unused)
+{
+	int i;
+
+	for (i = 0; i < CONFIG_MAX_MEI_DEVICES; i++)
+		fill_cse_fwsts(&fwsts_cache[i], i);
+}
+
+BOOT_STATE_INIT_ENTRY(BS_PRE_DEVICE, BS_ON_ENTRY, cache_cse_fwsts, NULL);
+
+int cse_write_smbios_type14(int *handle, unsigned long *current)
+{
+	int i, len;
+	char name[5];
+	struct smbios_type14 *t = smbios_carve_table(*current, SMBIOS_GROUP_ASSOCIATIONS,
+						     sizeof(*t), *handle);
+
+	*handle += 1;
+	t->group_name = smbios_add_string(t->eos, "$MEI");
+	t->item_type = 0xdb;
+	t->item_handle = *handle;
+
+	len = smbios_full_table_len(&t->header, t->eos);
+
+	struct fwsts_smbios_table *fwsts = smbios_carve_table(*current + len, 0xdb,
+							      sizeof(*fwsts), *handle);
+
+	*handle += 1;
+	fwsts->version = 1;
+	fwsts->count = CONFIG_MAX_MEI_DEVICES;
+
+	for (i = 0; i < CONFIG_MAX_MEI_DEVICES; i++) {
+		snprintf(name, sizeof(name), "MEI%d", i + 1);
+		fwsts->record[i].heci_name = smbios_add_string(fwsts->eos, name);
+		memcpy(fwsts->record[i].reg, fwsts_cache[i].reg, sizeof(fwsts->record[i].reg));
+	}
+
+	len += smbios_full_table_len(&fwsts->header, fwsts->eos);
+	*current += len;
+
+	return len;
+}
+#endif
 
 #if ENV_RAMSTAGE && !CONFIG(BOARD_NOVACUSTOM_NUC_BOX)
 static void heci_read_resources(struct device *dev)

--- a/src/soc/intel/common/block/include/intelblocks/cse.h
+++ b/src/soc/intel/common/block/include/intelblocks/cse.h
@@ -625,4 +625,8 @@ bool is_cse_fw_update_required(void);
  */
 bool is_cse_boot_to_rw(void);
 
+unsigned int soc_get_heci_dev(unsigned int heci_idx);
+
+int cse_write_smbios_type14(int *handle, unsigned long *current);
+
 #endif // SOC_INTEL_COMMON_CSE_H

--- a/src/soc/intel/denverton_ns/Kconfig
+++ b/src/soc/intel/denverton_ns/Kconfig
@@ -74,6 +74,14 @@ config MAX_CPUS
 	int
 	default 16
 
+config MAX_HECI_DEVICES
+	int
+	default 5
+
+config MAX_MEI_DEVICES
+	int
+	default 3
+
 config PCR_BASE_ADDRESS
 	hex
 	default 0xfd000000

--- a/src/soc/intel/denverton_ns/Makefile.mk
+++ b/src/soc/intel/denverton_ns/Makefile.mk
@@ -68,6 +68,8 @@ verstage-y += spi.c
 verstage-y += tsc_freq.c
 verstage-$(CONFIG_DRIVERS_UART_8250MEM) += uart_debug.c
 
+all-y += me.c
+
 CPPFLAGS_common += -I$(src)/soc/intel/denverton_ns/include
 
 cpu_microcode_bins += 3rdparty/intel-microcode/intel-ucode/06-5f-01

--- a/src/soc/intel/denverton_ns/me.c
+++ b/src/soc/intel/denverton_ns/me.c
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include <intelblocks/cse.h>
+#include <soc/pci_devs.h>
+
+unsigned int soc_get_heci_dev(unsigned int heci_idx)
+{
+	if (heci_idx > 2)
+		return 0;
+
+	static const unsigned int heci_devs[] = {
+		PCH_DEVFN_ME_HECI1,
+		PCH_DEVFN_ME_HECI2,
+		PCH_DEVFN_ME_HECI3,
+	};
+
+	return heci_devs[heci_idx];
+}

--- a/src/soc/intel/skylake/Kconfig
+++ b/src/soc/intel/skylake/Kconfig
@@ -94,6 +94,10 @@ config MAX_HECI_DEVICES
 	int
 	default 5
 
+config MAX_MEI_DEVICES
+	int
+	default 3
+
 config MAX_CPUS
 	int
 	default 16 if MAINBOARD_SUPPORTS_COFFEELAKE_CPU

--- a/src/soc/intel/skylake/me.c
+++ b/src/soc/intel/skylake/me.c
@@ -181,6 +181,20 @@ static const char *const me_progress_bup_values[] = {
 	"M0 kernel load",
 };
 
+unsigned int soc_get_heci_dev(unsigned int heci_idx)
+{
+	if (heci_idx > 2)
+		return 0;
+
+	static const unsigned int heci_devs[] = {
+		PCH_DEVFN_CSE,
+		PCH_DEVFN_CSE_2,
+		PCH_DEVFN_CSE_3
+	};
+
+	return heci_devs[heci_idx];
+}
+
 void intel_me_status(void)
 {
 	union me_hfsts1 hfs1;


### PR DESCRIPTION
Expose HFSTS registers via SMBIOS to allow EDK2 to determine if platform is fused or not.

Bump EDK2 for Boot Guard signing key check: https://github.com/Dasharo/edk2/pull/285

*ref: ncm-2095*