### PR TITLE
mb/protectli/vault_adl_n: vp2440: reenable ASPM and disable clk gating

### DIFF
--- a/src/mainboard/protectli/vault_adl_n/mainboard.c
+++ b/src/mainboard/protectli/vault_adl_n/mainboard.c
@@ -85,6 +85,15 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 		 * params->PcieRpEnableCpm[10] = 1;
 		 */
 		params->PcieRpEnableCpm[11] = 1;
+
+		/*
+		 * VP2430 does not have clock gating, because not all CLKREQs are
+		 * connected. In tests, this meant that network performance was higher.
+		 * Disable clock gating manually on VP2440 to make it perform in line
+		 * with VP2430.
+		 */
+		params->PchPcieClockGating = false;
+		params->PchPciePowerGating = false;
 	}
 
 	// Enable port reset message on Type-C ports

--- a/src/mainboard/protectli/vault_adl_n/variants/vp2440/overridetree.cb
+++ b/src/mainboard/protectli/vault_adl_n/variants/vp2440/overridetree.cb
@@ -63,7 +63,6 @@ chip soc/intel/alderlake
 		device ref pcie_rp7 on
 			register "pch_pcie_rp[PCH_RP(7)]" = "{
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
-				.pcie_rp_aspm = ASPM_DISABLE,
 				.clk_src = 0,
 				.clk_req = 0,
 			}"
@@ -96,7 +95,6 @@ chip soc/intel/alderlake
 		device ref pcie_rp12 on
 			register "pch_pcie_rp[PCH_RP(12)]" = "{
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
-				.pcie_rp_aspm = ASPM_DISABLE,
 				.clk_src = 1,
 				.clk_req = 1,
 			}"


### PR DESCRIPTION
It was found that this change improves idle power draw by 1.8 W, while also ensuring that the platform behaves the same as VP2430 with regards to ASPM.

Upstream-Status: Pending
Change-Id: Icd174e4694e86bc98d4d9b68e1cc124bc4b22d2f