### PR TITLE
drivers/efi/capsules.c: auto-set attempt_slot_b on capsule detection

### DIFF
--- a/src/drivers/efi/capsules.c
+++ b/src/drivers/efi/capsules.c
@@ -23,6 +23,9 @@
 #include <Guid/FmpCapsule.h>
 #include <IndustryStandard/WindowsUxCapsule.h>
 
+/* Weak default - platforms can override to prepare redundant slots */
+__weak void efi_capsule_update_prepare_redundant_slot(void) { }
+
 /*
  * Overview
  *
@@ -801,7 +804,7 @@ BOOT_STATE_INIT_ENTRY(BS_DEV_INIT, BS_ON_EXIT, parse_capsules, NULL);
 
 #endif
 
-static void enable_capsule_smi(void *unused)
+static void enable_capsule_update_path(void *unused)
 {
 	uint32_t ret;
 
@@ -824,6 +827,10 @@ static void enable_capsule_smi(void *unused)
 
 	printk(BIOS_INFO, "%sabled capsule update SMI handler\n",
 	       ret == SMMSTORE_RET_SUCCESS ? "En" : "Dis");
+
+	/* For redundancy-enabled platforms, ensure booting from Slot B */
+	if (full_flash_access)
+		efi_capsule_update_prepare_redundant_slot();
 }
 
-BOOT_STATE_INIT_ENTRY(BS_POST_DEVICE, BS_ON_ENTRY, enable_capsule_smi, NULL);
+BOOT_STATE_INIT_ENTRY(BS_POST_DEVICE, BS_ON_ENTRY, enable_capsule_update_path, NULL);

--- a/src/drivers/efi/capsules.h
+++ b/src/drivers/efi/capsules.h
@@ -24,4 +24,12 @@ static inline void efi_add_capsules_to_bootmem(void) { }
 
 #endif
 
+/*
+ * Called when UEFI update capsules are detected.
+ *
+ * Platform-specific code can override this to prepare for capsule updates,
+ * e.g., to switch to a redundant firmware slot for safe updates.
+ */
+void efi_capsule_update_prepare_redundant_slot(void);
+
 #endif /* _EDK2_CAPSULES_H_ */

--- a/src/soc/intel/common/block/rtc/rtc.c
+++ b/src/soc/intel/common/block/rtc/rtc.c
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
+#include <console/console.h>
+#include <drivers/efi/capsules.h>
 #include <fmap.h>
 #include <intelblocks/pcr.h>
 #include <intelblocks/rtc.h>
@@ -44,6 +46,19 @@ void rtc_conf_set_bios_interface_lockdown(void)
 }
 
 #if CONFIG(INTEL_HAS_TOP_SWAP)
+
+/*
+ * When UEFI update capsules are detected, enable the attempt_slot_b CMOS option
+ * so that the next boot will use the Top Swap (slot B) region for safe updates.
+ */
+void efi_capsule_update_prepare_redundant_slot(void)
+{
+	if (CONFIG(INTEL_TOP_SWAP_OPTION_CONTROL)) {
+		printk(BIOS_INFO, "Top Swap: enabling slot B for capsule update\n");
+		set_uint_option(TOP_SWAP_ENABLE_CMOS_OPTION, 1);
+	}
+}
+
 void configure_rtc_buc_top_swap(enum ts_config ts_state)
 {
 	pcr_rmw32(PID_RTC, PCR_RTC_BUC, ~PCR_RTC_BUC_TOP_SWAP, ts_state);


### PR DESCRIPTION
*ref: prot-2021*