### PR TITLE
mb/novacustom/mtl-h: Bump Energy Performance Preference to 45%

### DIFF
--- a/src/mainboard/novacustom/mtl-h/variants/dgpu/overridetree.cb
+++ b/src/mainboard/novacustom/mtl-h/variants/dgpu/overridetree.cb
@@ -11,6 +11,10 @@ chip soc/intel/meteorlake
 	# MTL SOC has additional setting for PsysPmax
 	register "psys_pmax_watts" = "180"
 
+	# set EPP to 45%: 45 * 256/100 = 115 = 0x73
+	register "enable_energy_perf_pref" = "true"
+	register "energy_perf_pref_value" = "0x73"
+
 	device domain 0 on
 		subsystemid 0x1558 0xa741 inherit
 		device ref pcie_rp12 on # PEG

--- a/src/mainboard/novacustom/mtl-h/variants/igpu/overridetree.cb
+++ b/src/mainboard/novacustom/mtl-h/variants/igpu/overridetree.cb
@@ -11,6 +11,10 @@ chip soc/intel/meteorlake
 	# MTL SOC has additional setting for PsysPmax
 	register "psys_pmax_watts" = "99"
 
+	# set EPP to 45%: 45 * 256/100 = 115 = 0x73
+	register "enable_energy_perf_pref" = "true"
+	register "energy_perf_pref_value" = "0x73"
+
 	device domain 0 on
 		subsystemid 0x1558 0xa743 inherit
 		device ref igpu on


### PR DESCRIPTION
Improve performance by lowering the EPP value from the power-on default of 0xb3 (70%) to 0x73 (45%). Lower value = higher performance.

Fixes https://github.com/Dasharo/dasharo-issues/issues/1711

Upstream-Status: Pending
Change-Id: I5a1f48dd2b563cf7dc37f7682317e5b7f81ad13c

*ref: ncm-2109*