### PR TITLE
security/intel/cbnt/measurement.c: fix PCR-0 hash missing BPM

### DIFF
--- a/src/security/intel/cbnt/measurement.c
+++ b/src/security/intel/cbnt/measurement.c
@@ -722,7 +722,7 @@ static void measure_intel_tgl_style(uint64_t biosacm_policy, bool auth_measure)
 		}
 
 		if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data,
-				       obuf_nr_written(&data_ob), alg,
+				       obuf_nr_written(&local_ob), alg,
 				       &pcr0_digests.hashes[i])) {
 			printk(BIOS_ERR, "CBnT: failed to hash PCR-0 measurement data\n");
 			return;
@@ -857,7 +857,7 @@ static void measure_tcg_style(uint64_t biosacm_policy)
 		}
 
 		if (vb2_hash_calculate(vboot_hwcrypto_allowed(), data,
-				       obuf_nr_written(&data_ob), alg,
+				       obuf_nr_written(&local_ob), alg,
 				       &policy_digests.hashes[i])) {
 			printk(BIOS_ERR, "CBnT: failed to hash PCR-0 measurement data\n");
 			return;


### PR DESCRIPTION
When the per-bank hash loop was introduced, the hash length was accidentally left pointing at the pre-loop write position, so BPM signature and IBB digest were never included in the computed hash. Fix by using the correct post-write length.

Makes PCR-0 reconstruction valid on ADL-P.

Upstream-Status: Pending