### PR TITLE
security/intel/acm/Makefile.mk: add ACM's to both FIT tables

### DIFF
--- a/src/security/intel/acm/Makefile.mk
+++ b/src/security/intel/acm/Makefile.mk
@@ -17,11 +17,11 @@ $(call add_intermediate, add_acm_fit, $(IFITTOOL) set_fit_ptr)
 	$(IFITTOOL) -r $(BB_FIT_REGION) -a -n $(CONFIG_INTEL_TXT_CBFS_BIOS_ACM) -t 2 \
 		-s $(CONFIG_CPU_INTEL_NUM_FIT_ENTRIES) -f $<
 
-ifneq ($(CONFIG_INTEL_TOP_SWAP_SEPARATE_REGIONS),y)
+ifeq ($(CONFIG_INTEL_ADD_TOP_SWAP_BOOTBLOCK),y)
 $(call add_intermediate, add_acm_ts_fit, $(IFITTOOL) set_fit_ptr)
-	$(IFITTOOL) -r TOPSWAP -a -n $(CONFIG_INTEL_TXT_CBFS_BIOS_ACM) -t 2 \
+	$(IFITTOOL) -r $(TS_FIT_REGION) -a -n $(CONFIG_INTEL_TXT_CBFS_BIOS_ACM) -t 2 \
 		-s $(CONFIG_CPU_INTEL_NUM_FIT_ENTRIES) -f $<
-endif # INTEL_TOP_SWAP_SEPARATE_REGIONS
+endif # INTEL_ADD_TOP_SWAP_BOOTBLOCK
 
 endif # CPU_INTEL_FIRMWARE_INTERFACE_TABLE
 


### PR DESCRIPTION
Prior to this, with redundancy and Boot Guard enabled, FIT in TOPSWAP lacked the BIOS ACM.

Upstream-Status: Pending