### PR TITLE
mb/protectli/vault_jsl: Remove SATA support on M.2 slot

### DIFF
--- a/src/mainboard/protectli/vault_jsl/devicetree.cb
+++ b/src/mainboard/protectli/vault_jsl/devicetree.cb
@@ -44,9 +44,6 @@ chip soc/intel/jasperlake
 	register "usb2_wake_enable_bitmap" = "0x0002"
 	register "usb3_wake_enable_bitmap" = "0x0001"
 
-	register "SataSalpSupport" = "1"
-	register "SataPortsEnable[1]" = "1"
-
 	register "gen1_dec" = "0x003c0a01"
 	register "gen2_dec" = "0x000c0081"
 	register "gen3_dec" = "0x00fc0201"
@@ -107,7 +104,6 @@ chip soc/intel/jasperlake
 		device pci 16.1 off end # HECI 2
 		device pci 16.4 off end # HECI 3
 		device pci 16.5 off end # HECI 4
-		device pci 17.0 on  end # SATA
 		device pci 19.0 off end # I2C 4
 		device pci 19.1 off end # I2C 5
 		device pci 19.2 off end # UART 2

--- a/src/mainboard/protectli/vault_jsl/mainboard.c
+++ b/src/mainboard/protectli/vault_jsl/mainboard.c
@@ -2,113 +2,15 @@
 
 #include <arch/mmio.h>
 #include <device/device.h>
-#include <fmap.h>
 #include <gpio.h>
 #include <pc80/i8254.h>
 #include <smbios.h>
 #include <soc/gpio.h>
-#include <soc/intel/common/reset.h>
 #include <soc/iomap.h>
 #include <soc/ramstage.h>
 
 #define FSP_PCH_PCIE_ASPM_DISABLE 0
 #define FSP_PCH_PCIE_ASPM_L0S 1
-
-#define IFD_FIA_COMBO_PORT0	0x189
-#define  FIA_PCIE		5
-#define  FIA_SATA		7
-
-/* Flash Master 1 : HOST/BIOS */
-#define FLMSTR1			0x80
-/* Flash signature Offset */
-#define FLASH_SIGN_OFFSET	0x10
-#define FLMSTR_WR_SHIFT_V2	20
-#define FLASH_VAL_SIGN		0xFF0A55A
-#define SI_DESC_SIZE		0x1000
-#define SI_DESC_REGION		"SI_DESC"
-
-/* It checks whether host (Flash Master 1) has write access to the Descriptor Region or not */
-static bool is_descriptor_writeable(uint8_t *desc)
-{
-	/* Check flash has valid signature */
-	if (read32((void *)(desc + FLASH_SIGN_OFFSET)) != FLASH_VAL_SIGN) {
-		printk(BIOS_ERR, "Flash Descriptor is not valid\n");
-		return 0;
-	}
-	/* Check host has write access to the Descriptor Region */
-	if (!((read32((void *)(desc + FLMSTR1)) >> FLMSTR_WR_SHIFT_V2) & BIT(0))) {
-		printk(BIOS_ERR, "Host doesn't have write access to Descriptor Region\n");
-		return 0;
-	}
-	return 1;
-}
-
-static void descriptor_patch_pcie8_lane(int is_nvme)
-{
-	uint8_t *si_desc_buf;
-	struct region_device desc_rdev;
-	uint8_t state = is_nvme ? FIA_PCIE : FIA_SATA;
-
-	si_desc_buf = (uint8_t *)malloc(SI_DESC_SIZE);
-
-	if (!si_desc_buf) {
-		printk(BIOS_ERR, "Failed to allocate buffer for %s\n", SI_DESC_REGION);
-		return;
-	}
-
-	if (fmap_locate_area_as_rdev_rw(SI_DESC_REGION, &desc_rdev) < 0) {
-		printk(BIOS_ERR, "Failed to locate %s in the FMAP\n", SI_DESC_REGION);
-		free(si_desc_buf);
-		return;
-	}
-	if (rdev_readat(&desc_rdev, si_desc_buf, 0, SI_DESC_SIZE) != SI_DESC_SIZE) {
-		printk(BIOS_ERR, "Failed to read Descriptor Region from SPI Flash\n");
-		free(si_desc_buf);
-		return;
-	}
-	if (!is_descriptor_writeable(si_desc_buf)) {
-		free(si_desc_buf);
-		return;
-	}
-
-	/*
-	 * Offset 0x189 bits [0:3]: 5=PCIe, 7=SATA.
-	 * Not patching the descriptor will result in SATA or NVMe not working.
-	 */
-	if ((si_desc_buf[IFD_FIA_COMBO_PORT0] & 0xf) == state) {
-		printk(BIOS_DEBUG, "Update of Descriptor is not required!\n");
-		free(si_desc_buf);
-		return;
-	}
-
-	si_desc_buf[IFD_FIA_COMBO_PORT0] &= 0xf0;
-	si_desc_buf[IFD_FIA_COMBO_PORT0] |= state;
-
-	/* FIT als sets reserved offset 0x1a4 bits [0:3]: 5=PCIe, 1=SATA */
-	if (state == FIA_PCIE) {
-		si_desc_buf[0x1a4] &= 0xf0;
-		si_desc_buf[0x1a4] |= 5;
-	} else {
-		si_desc_buf[0x1a4] &= 0xf0;
-		si_desc_buf[0x1a4] |= 1;
-	}
-
-	if (rdev_eraseat(&desc_rdev, 0, SI_DESC_SIZE) != SI_DESC_SIZE) {
-		printk(BIOS_ERR, "Failed to erase Descriptor Region area\n");
-		free(si_desc_buf);
-		return;
-	}
-
-	if (rdev_writeat(&desc_rdev, si_desc_buf, 0, SI_DESC_SIZE) != SI_DESC_SIZE) {
-		printk(BIOS_ERR, "Failed to update Descriptor Region\n");
-		free(si_desc_buf);
-		return;
-	}
-
-	printk(BIOS_DEBUG, "Update of Descriptor successful\n");
-	free(si_desc_buf);
-	do_global_reset();
-}
 
 smbios_enclosure_type smbios_mainboard_enclosure_type(void)
 {
@@ -188,17 +90,6 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 		params->PcieRpLtrEnable[i] = 1;
 		params->PcieRpMaxPayload[i] = 1; // 256B
 		params->PcieRpSlotImplemented[i] = 1;
-	}
-
-	if (CONFIG(BOARD_PROTECTLI_V1610)) {
-		/* Read GPP_C6 (M2_PEDET) to check for disk type: 1=NVME, 0=SATA */
-		gpio_input_pullup(GPP_C6);
-		/*
-		 * Patch the descriptor accordingly, by default the lanes 7 and 8
-		 * are in 1x2 mode. Lane 8 can be statically assigned to either
-		 * PCIe or SATA
-		 */
-		descriptor_patch_pcie8_lane(gpio_get(GPP_C6));
 	}
 
 	/*

--- a/src/mainboard/protectli/vault_jsl/override_v12xx.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v12xx.cb
@@ -1,7 +1,6 @@
 chip soc/intel/jasperlake
 	device domain 0 on
-		# Using x2 link on PCIe 5/6 to avoid switching to SATA
-		device pci 1c.0 on	# PCI Express Root Port 1
+		device pci 1c.0 on	    # PCI Express Root Port 1
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"
 		end

--- a/src/mainboard/protectli/vault_jsl/override_v12xx.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v12xx.cb
@@ -1,12 +1,12 @@
 chip soc/intel/jasperlake
 	device domain 0 on
-		device pci 1c.0 on	    # PCI Express Root Port 1
+		device pci 1c.0 off end # PCI Express Root Port 1
+		device pci 1c.1 off end # PCI Express Root Port 2
+		device pci 1c.2 off end # PCI Express Root Port 3
+		device pci 1c.3 on      # PCI Express Root Port 4
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"
 		end
-		device pci 1c.1 off end # PCI Express Root Port 2
-		device pci 1c.2 off end # PCI Express Root Port 3
-		device pci 1c.3 off end # PCI Express Root Port 4
 		device pci 1c.4 on      # PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"
@@ -17,6 +17,6 @@ chip soc/intel/jasperlake
 		device pci 1c.6 on # PCI Express Root Port 7 (LAN2)
 			smbios_dev_info 2
 		end
-		device pci 1c.7 off  end # PCI Express Root Port 8
+		device pci 1c.7 off end # PCI Express Root Port 8
 	end
 end

--- a/src/mainboard/protectli/vault_jsl/override_v1410.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1410.cb
@@ -6,11 +6,11 @@ chip soc/intel/jasperlake
 		device pci 1c.1 on # PCI Express Root Port 2 (LAN2)
 			smbios_dev_info 2
 		end
-		device pci 1c.2 on	# PCI Express Root Port 3
+		device pci 1c.2 off end # PCI Express Root Port 3
+		device pci 1c.3 on # PCI Express Root Port 4
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth1X"
 		end
-		device pci 1c.3 off end # PCI Express Root Port 4
 		device pci 1c.4 on	# PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"

--- a/src/mainboard/protectli/vault_jsl/override_v1410.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1410.cb
@@ -6,8 +6,6 @@ chip soc/intel/jasperlake
 		device pci 1c.1 on # PCI Express Root Port 2 (LAN2)
 			smbios_dev_info 2
 		end
-		# NVMe x1 link, making it x2 link with lane reversal
-		# would mess up the LAN port order
 		device pci 1c.2 on	# PCI Express Root Port 3
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth1X"

--- a/src/mainboard/protectli/vault_jsl/override_v1610.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1610.cb
@@ -3,7 +3,6 @@ chip soc/intel/jasperlake
 		# ASMedia PCIe switch with x2 link to 4x1 ports (3 LANs and WiFi)
 		device pci 1c.0 on	end # PCI Express Root Port 1
 		device pci 1c.1 off	end	# PCI Express Root Port 2
-		# NVMe with x2 link, lane 8 switchable to SATA
 		device pci 1c.2 on	# PCI Express Root Port 3
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"

--- a/src/mainboard/protectli/vault_jsl/override_v1610.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1610.cb
@@ -3,11 +3,11 @@ chip soc/intel/jasperlake
 		# ASMedia PCIe switch with x2 link to 4x1 ports (3 LANs and WiFi)
 		device pci 1c.0 on	end # PCI Express Root Port 1
 		device pci 1c.1 off	end	# PCI Express Root Port 2
-		device pci 1c.2 on	# PCI Express Root Port 3
+		device pci 1c.2 off end	# PCI Express Root Port 3
+		device pci 1c.3 on # PCI Express Root Port 4
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"
 		end
-		device pci 1c.3 off end # PCI Express Root Port 4
 		device pci 1c.4	on # PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"


### PR DESCRIPTION
Customer has requested disabling the capability.

Fixes compatibility with certain Samsung NVMe SSDs.

Upstream-Status: Pending
Change-Id: I997c372d1e17a954f6d28f55c9cc55a50ceb82df