### PR TITLE
Top-Swap fixes

### DIFF
--- a/src/arch/x86/Kconfig
+++ b/src/arch/x86/Kconfig
@@ -26,6 +26,10 @@ config ARCH_POSTCAR_X86_32
 config ARCH_RAMSTAGE_X86_32
 	bool
 
+config ARCH_SMM_X86_32
+	bool
+	default ARCH_RAMSTAGE_X86_32 && !NO_SMM
+
 config ARCH_ALL_STAGES_X86_32
 	bool
 	default !ARCH_ALL_STAGES_X86_64
@@ -56,6 +60,10 @@ config ARCH_POSTCAR_X86_64
 config ARCH_RAMSTAGE_X86_64
 	bool
 	select SSE2
+
+config ARCH_SMM_X86_64
+	bool
+	default ARCH_RAMSTAGE_X86_64 && !NO_SMM
 
 config ARCH_ALL_STAGES_X86_64
 	bool

--- a/src/arch/x86/Makefile.mk
+++ b/src/arch/x86/Makefile.mk
@@ -4,6 +4,12 @@ ifeq ($(CONFIG_POSTCAR_STAGE),y)
 $(eval $(call init_standard_toolchain,postcar))
 endif
 
+ifeq ($(CONFIG_ARCH_X86),y)
+ifneq ($(CONFIG_NO_SMM),y)
+$(eval $(call init_standard_toolchain,smm))
+endif
+endif
+
 ################################################################################
 # i386 specific tools
 NVRAMTOOL:=$(objutil)/nvramtool/nvramtool

--- a/src/cpu/x86/smm/Makefile.mk
+++ b/src/cpu/x86/smm/Makefile.mk
@@ -5,7 +5,7 @@ ramstage-$(CONFIG_SMM_PCI_RESOURCE_STORE) += pci_resource_store.c
 
 smm-$(CONFIG_SMM_PCI_RESOURCE_STORE) += pci_resource_store.c
 
-ifeq ($(CONFIG_ARCH_RAMSTAGE_X86_32),y)
+ifeq ($(CONFIG_ARCH_SMM_X86_32),y)
 $(eval $(call create_class_compiler,smm,x86_32))
 $(eval $(call create_class_compiler,smmstub,x86_32))
 else
@@ -51,7 +51,7 @@ ramstage-srcs += $(obj)/cpu/x86/smm/smmstub.manual
 $(obj)/smmstub/smmstub.o: $$(smmstub-objs) $(COMPILER_RT_smmstub)
 	$(LD_smmstub) -nostdlib -r -o $@ $(COMPILER_RT_FLAGS_smmstub) --whole-archive --start-group $(smmstub-objs) --no-whole-archive $(COMPILER_RT_smmstub) --end-group
 
-ifeq ($(CONFIG_ARCH_RAMSTAGE_X86_32),y)
+ifeq ($(CONFIG_ARCH_SMM_X86_32),y)
 $(eval $(call rmodule_link,$(obj)/smmstub/smmstub.elf, $(obj)/smmstub/smmstub.o,x86_32))
 else
 $(eval $(call rmodule_link,$(obj)/smmstub/smmstub.elf, $(obj)/smmstub/smmstub.o,x86_64))
@@ -66,7 +66,7 @@ $(call src-to-obj,ramstage,$(obj)/cpu/x86/smm/smmstub.manual): $(obj)/smmstub/sm
 
 # C-based SMM handler.
 
-ifeq ($(CONFIG_ARCH_RAMSTAGE_X86_32),y)
+ifeq ($(CONFIG_ARCH_SMM_X86_32),y)
 $(eval $(call rmodule_link,$(obj)/smm/smm.elf, $(obj)/smm/smm.a,x86_32))
 else
 $(eval $(call rmodule_link,$(obj)/smm/smm.elf, $(obj)/smm/smm.a,x86_64))

--- a/src/lib/cbfs.c
+++ b/src/lib/cbfs.c
@@ -200,12 +200,7 @@ static bool cbfs_file_hash_mismatch(const void *buffer, size_t size,
 
 	const struct vb2_hash *hash = NULL;
 
-	/*
-	 * Skipping this block in SMM because vboot library isn't linked to SMM stage.  This is
-	 * an issue only if using a CMOS options backend, then SMM refers to an option and tries
-	 * to verify cmos.layout here.
-	 */
-	if (CONFIG(CBFS_VERIFICATION) && !ENV_SMM && !skip_verification) {
+	if (CONFIG(CBFS_VERIFICATION) && !skip_verification) {
 		hash = cbfs_file_hash(mdata);
 		if (!hash) {
 			ERROR("'%s' does not have a file hash!\n", mdata->h.filename);

--- a/src/lib/cbfs.c
+++ b/src/lib/cbfs.c
@@ -499,6 +499,24 @@ static void *do_alloc(union cbfs_mdata *mdata, struct region_device *rdev,
 	return loc;
 }
 
+static enum cb_err check_or_query_type(const union cbfs_mdata *mdata, enum cbfs_type *type)
+{
+	if (type == NULL)
+		return CB_SUCCESS;
+
+	const enum cbfs_type real_type = be32toh(mdata->h.type);
+	if (*type == CBFS_TYPE_QUERY) {
+		*type = real_type;
+		return CB_SUCCESS;
+	}
+
+	if (*type == real_type)
+		return CB_SUCCESS;
+
+	ERROR("'%s' type mismatch (is %u, expected %u)\n", mdata->h.filename, real_type, *type);
+	return CB_ERR;
+}
+
 void *_cbfs_alloc(const char *name, cbfs_allocator_t allocator, void *arg,
 		  size_t *size_out, bool force_ro, enum cbfs_type *type)
 {
@@ -513,16 +531,8 @@ void *_cbfs_alloc(const char *name, cbfs_allocator_t allocator, void *arg,
 	if (_cbfs_boot_lookup(name, force_ro, &mdata, &rdev))
 		return NULL;
 
-	if (type) {
-		const enum cbfs_type real_type = be32toh(mdata.h.type);
-		if (*type == CBFS_TYPE_QUERY)
-			*type = real_type;
-		else if (*type != real_type) {
-			ERROR("'%s' type mismatch (is %u, expected %u)\n",
-			      mdata.h.filename, real_type, *type);
-			return NULL;
-		}
-	}
+	if (check_or_query_type(&mdata, type) != CB_SUCCESS)
+		return NULL;
 
 	/* Update the rdev with the preload content */
 	if (!force_ro && get_preload_rdev(&rdev, name) == CB_SUCCESS)
@@ -563,16 +573,8 @@ void *_cbfs_unverified_area_alloc(const char *area, const char *name,
 		return NULL;
 	}
 
-	if (type) {
-		const enum cbfs_type real_type = be32toh(mdata.h.type);
-		if (*type == CBFS_TYPE_QUERY)
-			*type = real_type;
-		else if (*type != real_type) {
-			ERROR("'%s' type mismatch (is %u, expected %u)\n",
-			      mdata.h.filename, real_type, *type);
-			return NULL;
-		}
-	}
+	if (check_or_query_type(&mdata, type) != CB_SUCCESS)
+		return NULL;
 
 	if (rdev_chain(&file_rdev, &area_rdev, data_offset, be32toh(mdata.h.len)))
 		return NULL;

--- a/src/security/tpm/tspi/crtm.c
+++ b/src/security/tpm/tspi/crtm.c
@@ -10,10 +10,6 @@
 #include <string.h>
 #include <security/intel/cbnt/cbnt.h>
 
-/* This include is available as <intelblocks/rtc.h> only if CONFIG_SOC_INTEL_COMMON_BLOCK is
-   set, which is not guaranteed for this file. */
-#include <soc/intel/common/block/include/intelblocks/rtc.h>
-
 static int tpm_log_initialized;
 bool tspi_tpm_log_available(void)
 {
@@ -72,14 +68,6 @@ tpm_result_t tspi_init_crtm(void)
 		void *mapping = NULL;
 
 		if (CONFIG(INTEL_TOP_SWAP_SEPARATE_REGIONS)) {
-			enum ts_config top_swap = get_rtc_buc_top_swap_status();
-			if (top_swap == TS_ENABLE)
-				printk(BIOS_INFO,
-				       "CRTM Top Swap: Measuring bootblock in TOPSWAP (will be logged as BOOTBLOCK).\n");
-			else
-				printk(BIOS_INFO,
-				       "CRTM Top Swap: Measuring bootblock in BOOTBLOCK.\n");
-
 			/*
 			 * Whether Top Swap is active or not, FMAP always refers to the same
 			 * memory ranges but the contents of BOOTBLOCK and TOPSWAP are swapped.

--- a/src/security/vboot/Makefile.mk
+++ b/src/security/vboot/Makefile.mk
@@ -7,6 +7,7 @@ verstage-y += vboot_lib.c
 romstage-y += vboot_lib.c
 ramstage-y += vboot_lib.c
 postcar-y += vboot_lib.c
+smm-y += vboot_lib.c
 
 vboot-fixup-includes = $(patsubst -I%,-I$(top)/%,\
 		       $(patsubst $(src)/%.h,$(top)/$(src)/%.h,\
@@ -53,6 +54,7 @@ $(eval $(call vboot-for-stage,romstage))
 endif
 $(eval $(call vboot-for-stage,ramstage))
 $(eval $(call vboot-for-stage,postcar))
+$(eval $(call vboot-for-stage,smm))
 
 endif # CONFIG_VBOOT_LIB
 

--- a/util/cbfstool/cbfstool.c
+++ b/util/cbfstool/cbfstool.c
@@ -118,6 +118,15 @@ static struct param {
 	.u64val = -1,
 };
 
+/* Indicates which CBFS is described by an mh_cache. Multiple firmware slots imply multiple
+   hash anchors, necessitating differentiating between them when caching. */
+enum mhc_kind {
+	MHC_NONE,    /* The cache is uninitialized. */
+	MHC_PRIMARY, /* Normal and always-present "COREBOOT" CBFS (separate or embedded
+			bootblock). */
+	MHC_TOPSWAP  /* Top Swap CBFS called "COREBOOT_TS" with bootblock in "TOPSWAP". */
+};
+
 /*
  * This "metadata_hash cache" caches the value and location of the CBFS metadata
  * hash embedded in the bootblock when CBFS verification is enabled. The first
@@ -132,7 +141,7 @@ struct mh_cache {
 	size_t offset;
 	struct vb2_hash cbfs_hash;
 	platform_fixup_func fixup;
-	bool initialized;
+	enum mhc_kind kind;
 };
 
 static bool is_main_cbfs_region(const char *region_name)
@@ -141,27 +150,39 @@ static bool is_main_cbfs_region(const char *region_name)
 		strcmp(region_name, SECTION_NAME_TOPSWAP_CBFS) == 0;
 }
 
-static bool is_topswap_region(const char *region_name)
+static enum mhc_kind derive_mhc_kind(const char *region_name)
 {
-	return strcmp(region_name, SECTION_NAME_TOPSWAP_CBFS) == 0 ||
-		strcmp(region_name, SECTION_NAME_TOPSWAP) == 0;
+	/* Only these two regions are specific to Top Swap. */
+	if (strcmp(region_name, SECTION_NAME_TOPSWAP_CBFS) == 0 ||
+	    strcmp(region_name, SECTION_NAME_TOPSWAP) == 0)
+		return MHC_TOPSWAP;
+
+	return MHC_PRIMARY;
 }
 
 static struct mh_cache *get_mh_cache(void)
 {
 	static struct mh_cache mhc;
 
-	if (mhc.initialized)
+	/*
+	 * A single invocation of cbfstool can process regions that use different CBFS metadata.
+	 * Right now, the only such case is when Top Swap redundancy is in use. Check for Top
+	 * Swap region to decide if the cache can be reused.
+	 *
+	 * This implicitly checks whether the cache is initialized.
+	 */
+	const enum mhc_kind kind = derive_mhc_kind(param.region_name);
+	if (mhc.kind == kind)
 		return &mhc;
 
-	mhc.initialized = true;
+	mhc.kind = kind;
 
 	const struct fmap *fmap = partitioned_file_get_fmap(param.image_file);
 	if (!fmap)
 		goto no_metadata_hash;
 
 	const char *bootblock_region = SECTION_NAME_BOOTBLOCK;
-	if (is_topswap_region(param.region_name))
+	if (kind == MHC_TOPSWAP)
 		bootblock_region = SECTION_NAME_TOPSWAP;
 
 	/* Find the metadata_hash container. If there is a "BOOTBLOCK" FMAP section, it's
@@ -175,6 +196,12 @@ static struct mh_cache *get_mh_cache(void)
 		offset = 0;
 		size = buffer.size;
 	} else {
+		if (kind != MHC_PRIMARY) {
+			/* Top Swap requires TOPSWAP region. */
+			ERROR("Malformed image: '%s' region is missing\n", bootblock_region);
+			goto no_metadata_hash;
+		}
+
 		struct cbfs_image cbfs;
 		struct cbfs_file *mh_container;
 		if (!partitioned_file_read_region(&buffer, param.image_file, SECTION_NAME_PRIMARY_CBFS))
@@ -2381,10 +2408,6 @@ int main(int argc, char **argv)
 		strcpy(region_name_scratch, param.region_name);
 		param.region_name = strtok(region_name_scratch, ",");
 		for (unsigned region = 0; region < num_regions; ++region) {
-			// Reset metadata cache in case region uses anchor from a different
-			// location.
-			get_mh_cache()->initialized = false;
-
 			if (!param.region_name) {
 				ERROR("Encountered illegal degenerate region name in -r list\n");
 				ERROR("The image will be left unmodified.\n");

--- a/util/cbfstool/cbfstool.c
+++ b/util/cbfstool/cbfstool.c
@@ -2392,7 +2392,8 @@ int main(int argc, char **argv)
 				return 1;
 			}
 
-			if (is_main_cbfs_region(param.region_name))
+			// "COREBOOT" CBFS region is a mandatory one.
+			if (strcmp(param.region_name, SECTION_NAME_PRIMARY_CBFS) == 0)
 				seen_primary_cbfs = true;
 
 			param.image_region = image_regions + region;


### PR DESCRIPTION
This backports fixes for Top-Swap redundancy committed in upstream:
 - [CB:92023](https://review.coreboot.org/c/coreboot/+/92023)
 - [CB:92024](https://review.coreboot.org/c/coreboot/+/92024)
 - [CB:92027](https://review.coreboot.org/c/coreboot/+/92027)
 - [CB:92026](https://review.coreboot.org/c/coreboot/+/92026)
 - [CB:92028](https://review.coreboot.org/c/coreboot/+/92028)
 - [CB:92025](https://review.coreboot.org/c/coreboot/+/92025)

The main change is that CBFS verification is not skipped in SMM.  There was also a bug in `cbfstool` that permitted creating an image with `COREBOOT_TS` and no `COREBOOT`.  The rest are essentially code improvements.

*ref: prot-2072*