### PR TITLE
Protectli V1xxx: Adjust NVMe link width to x2

### DIFF
--- a/src/mainboard/protectli/vault_jsl/mainboard.c
+++ b/src/mainboard/protectli/vault_jsl/mainboard.c
@@ -102,8 +102,7 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 	 * Disable ASPM L1 for SSD slot, as it does not work reliably with Samsung
 	 * NVMe SSDs.
 	 */
-	params->PcieRpAspm[CONFIG(BOARD_PROTECTLI_V1210) || CONFIG(BOARD_PROTECTLI_V1211) ? 0 : 2]
-		= FSP_PCH_PCIE_ASPM_L0S;
+	params->PcieRpAspm[0] = FSP_PCH_PCIE_ASPM_L0S;
 
 	/*
 	 * HWP is too aggressive in power savings and does not let using full

--- a/src/mainboard/protectli/vault_jsl/override_v12xx.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v12xx.cb
@@ -1,12 +1,9 @@
 chip soc/intel/jasperlake
 	device domain 0 on
-		device pci 1c.0 on	    # PCI Express Root Port 1
+		device pci 1c.0 on     # PCI Express Root Port 1 (NVMe)
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"
 		end
-		device pci 1c.1 off end # PCI Express Root Port 2
-		device pci 1c.2 off end # PCI Express Root Port 3
-		device pci 1c.3 off end # PCI Express Root Port 4
 		device pci 1c.4 on      # PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"

--- a/src/mainboard/protectli/vault_jsl/override_v12xx.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v12xx.cb
@@ -1,12 +1,12 @@
 chip soc/intel/jasperlake
 	device domain 0 on
-		device pci 1c.0 off end # PCI Express Root Port 1
-		device pci 1c.1 off end # PCI Express Root Port 2
-		device pci 1c.2 off end # PCI Express Root Port 3
-		device pci 1c.3 on      # PCI Express Root Port 4
+		device pci 1c.0 on	    # PCI Express Root Port 1
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"
 		end
+		device pci 1c.1 off end # PCI Express Root Port 2
+		device pci 1c.2 off end # PCI Express Root Port 3
+		device pci 1c.3 off end # PCI Express Root Port 4
 		device pci 1c.4 on      # PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"
@@ -17,6 +17,6 @@ chip soc/intel/jasperlake
 		device pci 1c.6 on # PCI Express Root Port 7 (LAN2)
 			smbios_dev_info 2
 		end
-		device pci 1c.7 off end # PCI Express Root Port 8
+		device pci 1c.7 off  end # PCI Express Root Port 8
 	end
 end

--- a/src/mainboard/protectli/vault_jsl/override_v1410.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1410.cb
@@ -1,16 +1,15 @@
 chip soc/intel/jasperlake
 	device domain 0 on
-		device pci 1c.0 on # PCI Express Root Port 1 (LAN1)
-			smbios_dev_info 1
-		end
-		device pci 1c.1 on # PCI Express Root Port 2 (LAN2)
-			smbios_dev_info 2
-		end
-		device pci 1c.2 on	# PCI Express Root Port 3
+		device pci 1c.0 on	# PCI Express Root Port 1
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth1X"
 		end
-		device pci 1c.3 off end # PCI Express Root Port 4
+		device pci 1c.2 on # PCI Express Root Port 3 (LAN2)
+			smbios_dev_info 2
+		end
+		device pci 1c.3 on # PCI Express Root Port 4 (LAN1)
+			smbios_dev_info 1
+		end
 		device pci 1c.4 on	# PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"

--- a/src/mainboard/protectli/vault_jsl/override_v1410.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1410.cb
@@ -6,11 +6,11 @@ chip soc/intel/jasperlake
 		device pci 1c.1 on # PCI Express Root Port 2 (LAN2)
 			smbios_dev_info 2
 		end
-		device pci 1c.2 off end # PCI Express Root Port 3
-		device pci 1c.3 on # PCI Express Root Port 4
+		device pci 1c.2 on	# PCI Express Root Port 3
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth1X"
 		end
+		device pci 1c.3 off end # PCI Express Root Port 4
 		device pci 1c.4 on	# PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"

--- a/src/mainboard/protectli/vault_jsl/override_v1610.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1610.cb
@@ -3,11 +3,11 @@ chip soc/intel/jasperlake
 		# ASMedia PCIe switch with x2 link to 4x1 ports (3 LANs and WiFi)
 		device pci 1c.0 on	end # PCI Express Root Port 1
 		device pci 1c.1 off	end	# PCI Express Root Port 2
-		device pci 1c.2 off end	# PCI Express Root Port 3
-		device pci 1c.3 on # PCI Express Root Port 4
+		device pci 1c.2 on	# PCI Express Root Port 3
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"
 		end
+		device pci 1c.3 off end # PCI Express Root Port 4
 		device pci 1c.4	on # PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"

--- a/src/mainboard/protectli/vault_jsl/override_v1610.cb
+++ b/src/mainboard/protectli/vault_jsl/override_v1610.cb
@@ -1,13 +1,11 @@
 chip soc/intel/jasperlake
 	device domain 0 on
-		# ASMedia PCIe switch with x2 link to 4x1 ports (3 LANs and WiFi)
-		device pci 1c.0 on	end # PCI Express Root Port 1
-		device pci 1c.1 off	end	# PCI Express Root Port 2
-		device pci 1c.2 on	# PCI Express Root Port 3
+		device pci 1c.0 on	# PCI Express Root Port 1
 			smbios_slot_desc "SlotTypeM2Socket3" "SlotLengthOther"
 					 "M.2/M 2280 (NVMe)" "SlotDataBusWidth2X"
 		end
-		device pci 1c.3 off end # PCI Express Root Port 4
+		# ASMedia PCIe switch with x2 link to 4x1 ports (3 LANs and WiFi)
+		device pci 1c.2 on	end # PCI Express Root Port 3
 		device pci 1c.4	on # PCI Express Root Port 5
 			smbios_slot_desc "SlotTypeM2Socket1_SD" "SlotLengthOther"
 					 "M.2/E 2230 (WIFI)" "SlotDataBusWidth1X"


### PR DESCRIPTION
IFD blob was adjusted such that the SSD now gets an x2 wide link. Adjust the devicetrees appropriately.

Needs https://github.com/Dasharo/dasharo-blobs/pull/56/changes