### PR TITLE
payloads/external/edk2/Kconfig.dasharo: Bump rev for capsule sig reproducibility

### DIFF
--- a/payloads/external/edk2/Kconfig.dasharo
+++ b/payloads/external/edk2/Kconfig.dasharo
@@ -4,7 +4,7 @@ config EDK2_REPOSITORY
 	default "https://github.com/Dasharo/edk2"
 
 config EDK2_TAG_OR_REV
-	default "927ef7baf858679032a48c6b565e288f893874d3"
+	default "0fb9d21dda61c310acc0de1c02bd8e9da7612055"
 
 config EDK2_SYSTEM76_EC_LOGGING
 	bool "Enable edk2 logging to System76 EC"


### PR DESCRIPTION
See https://github.com/Dasharo/edk2/pull/308

Upstream-Status: Inappropriate [Dasharo downstream]
Change-Id: I2c362f7d102671d123588fe41bee3381f543d9fb