### PR TITLE
mb/protectli/vault_ehl: Enable RST1 button signal GPIO input

### DIFF
--- a/src/mainboard/protectli/vault_ehl/bootblock.c
+++ b/src/mainboard/protectli/vault_ehl/bootblock.c
@@ -4,16 +4,32 @@
 #include <bootblock_common.h>
 #include <superio/ite/common/ite.h>
 #include <superio/ite/it8613e/it8613e.h>
+#include <device/pnp_ops.h>
+#include <superio/ite/common/ite_gpio.h>
+
 
 #define GPIO_DEV PNP_DEV(0x2e, IT8613E_GPIO)
 #define UART_DEV PNP_DEV(0x2e, IT8613E_SP1)
 
+static void ite_set_gpio_iobase(u16 iobase)
+{
+	pnp_enter_conf_state(GPIO_DEV);
+	pnp_set_logical_device(GPIO_DEV);
+	pnp_set_iobase(GPIO_DEV, PNP_IDX_IO1, iobase);
+	pnp_exit_conf_state(GPIO_DEV);
+}
+
+
 void bootblock_mainboard_early_init(void)
 {
+	ite_reg_write(GPIO_DEV, 0x25, 0x04);  /* mux: GP12 instead of PCIRST1# */
 	ite_reg_write(GPIO_DEV, 0x29, 0xc1);
 	ite_reg_write(GPIO_DEV, 0x2a, 0x00); /* Disable FAN_CTL4 */
 	ite_reg_write(GPIO_DEV, 0x2c, 0x41); /* disable k8 power seq */
 	ite_reg_write(GPIO_DEV, 0x2d, 0x02); /* PCICLK=25MHz */
+	ite_gpio_setup(GPIO_DEV, 12, ITE_GPIO_INPUT, ITE_GPIO_SIMPLE_IO_MODE, ITE_GPIO_PULLUP_ENABLE);
+	ite_set_gpio_iobase(0xa00);
+
 	ite_kill_watchdog(GPIO_DEV);
 	ite_enable_serial(UART_DEV, CONFIG_TTYS0_BASE);
 }

--- a/src/mainboard/protectli/vault_ehl/devicetree.cb
+++ b/src/mainboard/protectli/vault_ehl/devicetree.cb
@@ -203,7 +203,9 @@ chip soc/intel/elkhartlake
 				end
 				device pnp 2e.5 off end # Keyboard
 				device pnp 2e.6 off end # Mouse
-				device pnp 2e.7 off end # GPIO
+				device pnp 2e.7 on # GPIO
+					io 0x62 = 0xa00
+				end
 				device pnp 2e.a off end # CIR
 			end
 			chip drivers/pc80/tpm


### PR DESCRIPTION
The button sits on a multi-function pin of the IT8613E. Enabled the chip's GPIO block in devicetree.cb, muxed the pin to GP12 (away from PCIRST1#), and turned on its internal pull-up to make the signal go back to 1 after the button is released.

Upstream-Status: Inappropriate [Dasharo downstream]