### PR TITLE
mb/protectli/vault_cml: Enable FP_RST button signal GPIO input

### DIFF
--- a/src/mainboard/protectli/vault_cml/bootblock.c
+++ b/src/mainboard/protectli/vault_cml/bootblock.c
@@ -1,13 +1,23 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
 #include <bootblock_common.h>
+#include <device/pnp_ops.h>
 #include <soc/gpio.h>
 #include <superio/ite/common/ite.h>
+#include <superio/ite/common/ite_gpio.h>
 #include <superio/ite/it8784e/it8784e.h>
 #include "gpio.h"
 
 #define UART_DEV PNP_DEV(0x2e, IT8784E_SP1)
 #define GPIO_DEV PNP_DEV(0x2e, IT8784E_GPIO)
+
+static void ite_set_gpio_iobase(u16 iobase)
+{
+	pnp_enter_conf_state(GPIO_DEV);
+	pnp_set_logical_device(GPIO_DEV);
+	pnp_set_iobase(GPIO_DEV, PNP_IDX_IO1, iobase);
+	pnp_exit_conf_state(GPIO_DEV);
+}
 
 void bootblock_mainboard_early_init(void)
 {
@@ -25,6 +35,8 @@ void bootblock_mainboard_early_init(void)
 	ite_delay_pwrgd3(GPIO_DEV);
 	ite_kill_watchdog(GPIO_DEV);
 	ite_enable_serial(UART_DEV, CONFIG_TTYS0_BASE);
+	ite_gpio_setup(GPIO_DEV, 80, ITE_GPIO_INPUT, ITE_GPIO_SIMPLE_IO_MODE, ITE_GPIO_PULLUP_ENABLE);
+	ite_set_gpio_iobase(0xa00);
 }
 
 void bootblock_mainboard_init(void)

--- a/src/mainboard/protectli/vault_cml/devicetree.cb
+++ b/src/mainboard/protectli/vault_cml/devicetree.cb
@@ -210,7 +210,9 @@ chip soc/intel/cannonlake
 				end
 				device pnp 2e.5 off end	# Keyboard
 				device pnp 2e.6 off end	# Mouse
-				device pnp 2e.7 off end	# GPIO
+				device pnp 2e.7 on
+					io 0x62 = 0xa00
+				end	# GPIO
 				device pnp 2e.a off end	# CIR
 			end
 			chip drivers/pc80/tpm


### PR DESCRIPTION
The button sits on a single function pin of the IT8786.
Enabled the chip's GPIO block in devicetree.cb, and
configured the GP80 pin as an input in bootblock.
Mapped to /dev/port at `0xa07` bit `2`.

Upstream-Status: Inappropriate [Dasharo downstream]