### PR TITLE
mb/emulation/qemu-q35: don't select CONFIG_UNKNOWN_TSC_RATE

### DIFF
--- a/src/cpu/qemu-x86/Kconfig
+++ b/src/cpu/qemu-x86/Kconfig
@@ -6,7 +6,6 @@ config CPU_QEMU_X86
 	select HAVE_X86_64_SUPPORT
 	select UDELAY_TSC
 	select TSC_MONOTONIC_TIMER
-	select UNKNOWN_TSC_RATE
 	select NEED_SMALL_2MB_PAGE_TABLES	# QEMU doesn't support 1GB pages
 	select IDT_IN_EVERY_STAGE
 

--- a/src/mainboard/emulation/qemu-q35/Makefile.mk
+++ b/src/mainboard/emulation/qemu-q35/Makefile.mk
@@ -18,9 +18,11 @@ ramstage-y += cpu.c
 
 all-y += ../qemu-i440fx/fw_cfg.c
 all-y += ../qemu-i440fx/bootmode.c
+all-y += timer.c
 
 ramstage-$(CONFIG_CHROMEOS) += chromeos.c
 
 smm-y += ../qemu-i440fx/rom_media.c
 smm-y += memmap.c
 smm-y += smihandler.c
+smm-y += timer.c

--- a/src/mainboard/emulation/qemu-q35/timer.c
+++ b/src/mainboard/emulation/qemu-q35/timer.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include <cpu/x86/tsc.h>
+
+unsigned long tsc_freq_mhz(void)
+{
+	/* ACPI's Power Management Timer frequency is fixed at 3.579545 MHz. */
+	return 3579545 / 1000000;
+}


### PR DESCRIPTION
This option signifies missing implementation of `tsc_freq_mhz()` which results in `tsc_freq_mhz()` from `src/arch/x86/timestamp.c` returning zero. That zero in turn gets put into TIMESTAMP CBMEM table requiring payloads and user-space tools to figure the frequency on their own.

***

https://github.com/Dasharo/edk2/pull/281/changes/0beada20275388c4e3b2c8f82b966fd639c59948 fixed parsing of TIMESTAMP table, resulting in division by zero when starting QEMU.  Addressing it in coreboot, similarly to the fix for APUs in https://github.com/Dasharo/coreboot/pull/887.  This fixes CI failures like https://github.com/Dasharo/coreboot/actions/runs/26337084146/job/77532919152#step:11:13.