### PR TITLE
configs/config.protectli_vp2410_no_emmc: create config variant

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -383,6 +383,10 @@ case "$CMD" in
         BOARD="vp2410"
         build_protectli_vault
         ;;
+    "vp2410_noemmc" | "VP2410_noemmc" | "vp2410e" | "VP2410e")
+        BOARD="vp2410"
+        build_protectli_vault _no_emmc
+        ;;
     "vp2420" | "VP2420")
         BOARD="vp2420"
         build_protectli_vault

--- a/configs/config.protectli_vp2410_no_emmc
+++ b/configs/config.protectli_vp2410_no_emmc
@@ -11,6 +11,7 @@ CONFIG_IFWI_FILE_NAME="3rdparty/dasharo-blobs/$(MAINBOARDDIR)/ifwi.bin"
 CONFIG_HAVE_IFD_BIN=y
 CONFIG_TPM_MEASURED_BOOT=y
 CONFIG_BOARD_PROTECTLI_VP2410=y
+# CONFIG_ENABLE_EMMC is not set
 CONFIG_DRIVERS_UART_8250IO=y
 CONFIG_EDK2_BOOTSPLASH_FILE="3rdparty/dasharo-blobs/protectli/black_background.bmp"
 CONFIG_FSP_HEADER_PATH="3rdparty/dasharo-blobs/$(MAINBOARDDIR)/GeminilakeFspBinPkg/Include"

--- a/src/mainboard/protectli/vault_glk/Kconfig
+++ b/src/mainboard/protectli/vault_glk/Kconfig
@@ -26,7 +26,8 @@ config DEVICETREE
 
 config MAINBOARD_PART_NUMBER
 	string
-	default "VP2410"
+	default "VP2410" if ENABLE_EMMC
+	default "VP2410e"
 
 config MAINBOARD_FAMILY
 	default "Vault Pro"
@@ -49,6 +50,12 @@ config USE_LEGACY_8254_TIMER
 config FMDFILE
 	string
 	default "src/mainboard/\$(CONFIG_MAINBOARD_DIR)/board.fmd" if !VBOOT
+
+config ENABLE_EMMC
+	bool "Enable eMMC support"
+	default y
+	help
+	  Enable the eMMC storage controller
 
 config BEEP_ON_BOOT
 	bool "Beep on successful boot"

--- a/src/mainboard/protectli/vault_glk/mainboard.c
+++ b/src/mainboard/protectli/vault_glk/mainboard.c
@@ -4,6 +4,7 @@
 #include <device/device.h>
 #include <fsp/api.h>
 #include <pc80/i8254.h>
+#include <soc/pci_devs.h>
 #include <soc/ramstage.h>
 
 static void mainboard_final(void *chip_info)
@@ -77,6 +78,11 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *silconfig)
 	silconfig->PcieRpClkReqSupported[5] = 0x0;
 	silconfig->AdvancedErrorReporting[5] = 0x1;
 	silconfig->PmeInterrupt[5] = 0x1;
+
+	if (!CONFIG(ENABLE_EMMC)) {
+		silconfig->eMMCEnabled = 0;
+		pcidev_path_on_root(PCH_DEVFN_EMMC)->enabled = 0;
+	}
 }
 
 struct chip_operations mainboard_ops = {


### PR DESCRIPTION
Adds ENABLE_EMMC option (default y) to allow building firmware for VP2410e  a hardware variant without eMMC. When disabled, the product name reported via SMBIOS changes to "VP2410e".

`eMMCEnabled` is set by `parse_devicetree()` at the start of `platform_fsp_silicon_init_params_cb()`, before `mainboard_silicon_init_params()` is called. Overriding it directly in FSP UPD at the end of that function is sufficient to prevent FSP from initializing the controller.

`pcidev_path_on_root(PCH_DEVFN_EMMC)->enabled` is also cleared so the device does not appear in ACPI tables.

Upstream-Status: Inappropriate [Dasharo downstream]