### PR TITLE
mb/novacustom/nuc_box/var/nuc_box/overridetree.cb: disable PCI PM

### DIFF
--- a/src/mainboard/novacustom/nuc_box/variants/nuc_box/overridetree.cb
+++ b/src/mainboard/novacustom/nuc_box/variants/nuc_box/overridetree.cb
@@ -83,10 +83,11 @@ chip soc/intel/meteorlake
 			# M.2 Key-M1
 			# XXX: Schematics show RP[13:16] used
 			register "pcie_rp[PCH_RP(10)]" = "{
-				.clk_src = 8,
-				.clk_req = 8,
-				.flags = PCIE_RP_LTR | PCIE_RP_AER,
+				.flags = PCIE_RP_LTR | PCIE_RP_AER | PCIE_RP_CLK_REQ_UNUSED | PCIE_RP_CLK_SRC_UNUSED,
+				.pcie_rp_aspm = ASPM_DISABLE,
+				.PcieRpL1Substates = L1_SS_DISABLED,
 			}"
+			register "pcie_clk_config_flag[8]" = "PCIE_CLK_FREE_RUNNING"
 		end
 		device ref pcie_rp11 on
 			# M.2 Key-M2

--- a/src/mainboard/novacustom/nuc_box/variants/nuc_box/ramstage.c
+++ b/src/mainboard/novacustom/nuc_box/variants/nuc_box/ramstage.c
@@ -15,4 +15,9 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
 	// XXX: Enabling C10 reporting causes system to constantly enter and
 	// exit opportunistic suspend when idle.
 	params->PchEspiHostC10ReportEnable = 1;
+
+	// Disable PCIe power gating on the RP that does not have a clock request
+	// connected. Otherwise, the connected device will fail after exiting D3.
+	params->PciePowerGating[9] = false;
+	params->PcieClockGating[9] = false;
 }


### PR DESCRIPTION
Disable ASPM, L1 SS and CLK PM to get rid of AER errors.

Upstream-Status: Pending
Change-Id: Ia9a78ff19402e821bc1326dccd9d540d115a1c7d