### PR TITLE
amdblocks/spi: Fix SPI ROM mapping

### DIFF
--- a/src/soc/amd/common/block/include/amdblocks/spi.h
+++ b/src/soc/amd/common/block/include/amdblocks/spi.h
@@ -76,6 +76,17 @@ enum spi100_speed {
 #define SPI100_HOST_PREF_CONFIG		0x2c
 #define   SPI_RD4DW_EN_HOST		BIT(15)
 
+#define SPI_ROM2_OVERRIDE		0x30
+#define   SPI_ROM2_ADDR_BIT24_VAL	BIT(0)
+#define   SPI_ROM2_ADDR_BIT25_VAL	BIT(1)
+#define   SPI_ROM2_ADDR_BIT24_MASK	BIT(2)
+#define   SPI_ROM2_ADDR_BIT25_MASK	BIT(3)
+/* Below bit is only mentioned in PPRs in section
+ * "Programming for ROM Protection register".
+ * The register definition marks this bit as reserved.
+ */
+#define   SPI_FORCE_ROM3_MAP_TO_BANK3	BIT(4)
+
 #define SPI_STATUS			0x4c
 #define   SPI_DONE_BYTE_COUNT_SHIFT	0
 #define   SPI_DONE_BYTE_COUNT_MASK	0xff
@@ -84,8 +95,8 @@ enum spi100_speed {
 #define   SPI_FIFO_RD_PTR_SHIFT		16
 #define   SPI_FIFO_RD_PTR_MASK		0x7f
 
-#define SPI_ADDR32_CTRL0		0x50
-#define   SPI_ROM_ADDR_32BIT		BIT(0)
+#define SPI_ROM_ADDR32_CTRL0		0x50
+#define   SPI_ROM_ADDR32		BIT(0)
 
 #define SPI_ROM_PAGE			0x5c
 #define   SPI_ROM_PAGE_SEL		(BIT(0) | BIT(1))
@@ -146,11 +157,15 @@ void spi_write8(uint8_t reg, uint8_t val);
 void spi_write16(uint8_t reg, uint16_t val);
 void spi_write32(uint8_t reg, uint32_t val);
 
-/* Returns the active SPI ROM remapping
- * @param Returns the active remapping
- * @return 0 on success.
- */
-int fch_spi_rom_remapping(uint8_t *mapping);
+/* Returns the active SPI ROM remapping */
+uint8_t fch_spi_rom_remapping(void);
+uint32_t fch_spi_get_rom2_page(uint32_t rom2_base);
+uint64_t fch_spi_get_rom3_page(uint64_t rom3_base);
+bool fch_spi_rom3_maps_to_bank3(void);
+bool fch_spi_rom_32bit(void);
+
+/* Configures 4DW burst mode */
+void fch_spi_configure_4dw_burst(void);
 
 void fch_spi_config_modes(void);
 void fch_spi_backup_registers(void);

--- a/src/soc/amd/common/block/spi/fch_spi.c
+++ b/src/soc/amd/common/block/spi/fch_spi.c
@@ -49,10 +49,7 @@ void show_spi_speeds_and_modes(void)
 
 	uint16_t val16 = spi_read16(SPI100_SPEED_CONFIG);
 	uint32_t val32 = spi_read32(SPI_CNTRL0);
-	uint8_t val8;
-
-	/* Do not check return value. When reached here return value is always 0. */
-	fch_spi_rom_remapping(&val8);
+	uint8_t val8 = fch_spi_rom_remapping() & SPI_ROM_PAGE_SEL;
 
 	printk(BIOS_DEBUG, "SPI normal read speed: %s\n",
 	       spi_speed_str[DECODE_SPI_NORMAL_SPEED(val16)]);
@@ -66,8 +63,8 @@ void show_spi_speeds_and_modes(void)
 	       spi_read16(SPI100_ENABLE) & SPI_USE_SPI100 ? "Enabled" : "Disabled");
 	printk(BIOS_DEBUG, "SPI Read Mode: %s\n", read_mode_str[DECODE_SPI_READ_MODE(val32)]);
 	printk(BIOS_DEBUG, "SPI ROM mapping: %s\n", remapping[val8]);
-	printk(BIOS_DEBUG, "SPI ROM address: %ubit\n",
-		spi_read8(SPI_ADDR32_CTRL0) & SPI_ROM_ADDR_32BIT ? 32 : 24);
+	printk(BIOS_DEBUG, "SPI ROM address: %ubit\n", fch_spi_rom_32bit() ? 32 : 24);
+	printk(BIOS_DEBUG, "SPI ROM2 override: %x\n", spi_read16(SPI_ROM2_OVERRIDE));
 }
 
 void __weak mainboard_spi_cfg_override(uint8_t *fast_speed, uint8_t *read_mode)
@@ -97,8 +94,10 @@ static void fch_spi_set_spi100(uint8_t norm, uint8_t fast, uint8_t alt, uint8_t 
 	spi_write16(SPI100_ENABLE, SPI_USE_SPI100 | spi_read16(SPI100_ENABLE));
 }
 
-static void fch_spi_configure_4dw_burst(void)
+void fch_spi_configure_4dw_burst(void)
 {
+	assert(!rom_armor_enforced);
+
 	uint16_t val = spi_read16(SPI100_HOST_PREF_CONFIG);
 
 	if (CONFIG(SOC_AMD_COMMON_BLOCK_SPI_4DW_BURST))
@@ -116,13 +115,60 @@ static void fch_spi_set_read_mode(u32 mode)
 	spi_write32(SPI_CNTRL0, val | SPI_READ_MODE(mode));
 }
 
-int fch_spi_rom_remapping(uint8_t *mapping)
+uint8_t fch_spi_rom_remapping(void)
 {
-	if (rom_armor_enforced)
-		return -1;
+	assert(!rom_armor_enforced);
 
-	*mapping = spi_read8(SPI_ROM_PAGE) & SPI_ROM_PAGE_SEL;
-	return 0;
+	return spi_read8(SPI_ROM_PAGE);
+}
+
+uint32_t fch_spi_get_rom2_page(uint32_t rom2_base)
+{
+	assert(!rom_armor_enforced);
+
+	uint32_t page = rom2_base >> 24;
+	uint8_t rom2_override = spi_read8(SPI_ROM2_OVERRIDE);
+
+	if (rom2_override & SPI_ROM2_ADDR_BIT24_MASK){
+		page &= ~SPI_ROM2_ADDR_BIT24_VAL;
+		page |= rom2_override & SPI_ROM2_ADDR_BIT24_VAL;
+	}
+
+	if (rom2_override & SPI_ROM2_ADDR_BIT25_MASK){
+		page &= ~SPI_ROM2_ADDR_BIT25_VAL;
+		page |= rom2_override & SPI_ROM2_ADDR_BIT25_VAL;
+	}
+
+	if (fch_spi_rom_32bit())
+		page ^= (uint32_t)fch_spi_rom_remapping();
+
+	return (page << 24);
+}
+
+uint64_t fch_spi_get_rom3_page(uint64_t rom3_base)
+{
+	assert(!rom_armor_enforced);
+
+	uint64_t page = rom3_base >> 24;
+
+	if (fch_spi_rom_32bit())
+		page ^= (uint64_t)fch_spi_rom_remapping();
+
+	return (page << 24);
+}
+
+bool fch_spi_rom_32bit(void)
+{
+	assert(!rom_armor_enforced);
+
+	return !!(spi_read8(SPI_ROM_ADDR32_CTRL0) & SPI_ROM_ADDR32);
+}
+
+bool fch_spi_rom3_maps_to_bank3(void)
+{
+	assert(!rom_armor_enforced);
+
+	return !!(spi_read8(SPI_ROM2_OVERRIDE) & SPI_FORCE_ROM3_MAP_TO_BANK3);
 }
 
 void fch_spi_config_modes(void)

--- a/src/soc/amd/common/block/spi/mmap_boot.c
+++ b/src/soc/amd/common/block/spi/mmap_boot.c
@@ -3,6 +3,7 @@
 #include <boot_device.h>
 #include <endian.h>
 #include <spi_flash.h>
+#include <amdblocks/psp.h>
 #include <amdblocks/spi.h>
 
 #if CONFIG_ROM_SIZE >= (16 * MiB)
@@ -17,17 +18,27 @@
 static const struct mem_region_device boot_dev =
 	MEM_REGION_DEV_RO_INIT(rom_base, ROM_SIZE);
 
+static bool is_rom2_remapped(uint32_t rom2_start, uint32_t offset)
+{
+	uint32_t rom2_mask = (CONFIG_ROM_SIZE - 1) & 0xff000000;
+
+	return ((fch_spi_get_rom2_page(rom2_start) & rom2_mask) != (offset & rom2_mask));
+}
+
 const struct region_device *boot_device_ro(void)
 {
-	uint8_t mapping = 0;
 	/*
-	 * The following code assumes that ROM2 is mapped at flash offset 0. This is the default
-	 * configuration currently enforced by soft-straps.
-	 * When ROM Armor is enabled fch_spi_rom_remapping() returns failure as the SPIBAR is
-	 * no longer accessible.
+	 * The following code assumes that ROM2 is mapped at flash offset 0.
+	 * This is the default configuration currently enforced by soft-straps.
+	 * When ROM Armor is enabled, don't call FCH SPI functions
+	 * because the SPIBAR is no longer accessible.
 	 */
-	if (!fch_spi_rom_remapping(&mapping) && mapping != 0)
-		die("Non default SPI ROM remapping is not supported!");
+	if (!rom_armor_enforced && is_rom2_remapped((uint32_t)rom_base, 0))
+		die("Non default ROM2 remapping is not supported!");
+
+
+	/* FSP might reconfigure it, so initialize again in every stage */
+	fch_spi_configure_4dw_burst();
 
 	return &boot_dev.rdev;
 }

--- a/src/soc/amd/common/block/spi/mmap_boot_rom3.c
+++ b/src/soc/amd/common/block/spi/mmap_boot_rom3.c
@@ -73,25 +73,40 @@ static void initialize_window(const size_t win_idx, const enum window_type type,
  *                                                                            Host address
  *                                                                            space
  */
+static bool is_rom2_remapped(uint32_t rom2_start, uint32_t offset)
+{
+	uint32_t rom2_mask = (CONFIG_ROM_SIZE - 1) & 0xff000000;
+
+	return ((fch_spi_get_rom2_page(rom2_start) & rom2_mask) != (offset & rom2_mask));
+}
+
+static bool is_rom3_linear(uint64_t rom3_start, uint32_t offset, uint32_t size)
+{
+	/* All ROM3 accesses map to bank 3 (last 16MiB) of flash, so not linear */
+	if (fch_spi_rom3_maps_to_bank3())
+		return false;
+
+	uint32_t bank_addr;
+	uint32_t rom3_mask = (CONFIG_ROM_SIZE - 1) & 0xff000000;
+
+	for (uint32_t bank = offset; bank < offset + size; bank += 16 * MiB) {
+		bank_addr = fch_spi_get_rom3_page(rom3_start + bank);
+		if ((bank_addr & rom3_mask) != (bank & rom3_mask))
+			return false;
+	}
+
+	return true;
+}
+
+
 static void bios_mmap_init(void)
 {
 	static bool init_done;
 	size_t win_count = 0;
 	size_t map_win_size = 0;
-	uint8_t mapping = 0;
 
 	if (init_done)
 		return;
-
-	/*
-	 * The following code assumes that ROM2 is mapped at flash offset 0 and
-	 * that the ROM3 16MByte chunks are linear (0-1-2-3) or (3-2-1-0).
-	 * This is the default configuration currently enforced by soft-straps.
-	 * When ROM Armor is enabled, don't call fch_spi_rom_remapping()
-	 * because the SPIBAR is no longer accessible.
-	 */
-	if (!fch_spi_rom_remapping(&mapping) && mapping != 0 && mapping != 3)
-		die("Non default SPI ROM remapping is not supported!");
 
 	/*
 	 * By default, fixed decode window (maximum size 16MiB) is mapped just
@@ -101,6 +116,16 @@ static void bios_mmap_init(void)
 	size_t rom2_size = 0;
 	const uintptr_t rom2_start = lpc_get_rom2_region(&rom2_size);
 	if (rom2_start && rom2_size) {
+		/*
+		 * The following code assumes that ROM2 is mapped at flash offset 0.
+		 * This is the default configuration currently enforced by soft-straps.
+		 * When ROM Armor is enabled, don't call FCH SPI functions because the
+		 * SPIBAR is no longer accessible.
+		 */
+		if (!rom_armor_enforced && is_rom2_remapped(rom2_start, 0))
+			die("Non default ROM2 remapping is not supported!");
+
+
 		initialize_window(win_count, ROM2_DECODE_WINDOW, rom2_start, 0, rom2_size);
 		win_count++;
 		map_win_size += rom2_size;
@@ -120,6 +145,8 @@ static void bios_mmap_init(void)
 	const uint64_t rom3_end = rom3_start + rom3_size;
 
 	if (CONFIG_ROM_SIZE > 16 * MiB) {
+		if (!rom_armor_enforced)
+			assert(fch_spi_rom_32bit())
 		assert(rom3_start);
 		assert(rom3_size > 16 * MiB);
 		assert(DIV_ROUND_UP(rom3_end, GiB) < CONFIG_CPU_PT_ROM_MAP_GB);
@@ -131,9 +158,32 @@ static void bios_mmap_init(void)
 	    DIV_ROUND_UP(rom3_end, GiB) < CONFIG_CPU_PT_ROM_MAP_GB) {
 
 		const size_t ext_win_size = MIN(rom3_size, CONFIG_ROM_SIZE - rom2_size);
+		const bool rom3_linear = rom_armor_enforced ? false :
+					 is_rom3_linear(rom3_start, rom2_size, ext_win_size);
+		/*
+		 * The following code assumes that the ROM3 16MiB chunks are linear.
+		 * This is the default configuration currently enforced by soft-straps.
+		 * When ROM Armor is enabled, don't call FCH SPI functions because the
+		 * SPIBAR is no longer accessible.
+		 */
+		if (!rom3_linear && (ext_win_size > 16 * MiB))
+			die("Non default ROM3 remapping is not supported!");
 
-		initialize_window(win_count, ROM3_DECODE_WINDOW,
-				  rom3_start + rom2_size, rom2_size, ext_win_size);
+		/*
+		 * If the extended window is only 16 MiB (32MiB flash) we can map one
+		 * 16MiB in ROM3 even if not linear. However, if more windows are needed
+		 * to be mapped, they must be linear.
+		 */
+		if (rom3_linear)
+			initialize_window(win_count, ROM3_DECODE_WINDOW,
+					  rom3_start + rom2_size, rom2_size, ext_win_size);
+		else if (!rom_armor_enforced && !fch_spi_rom3_maps_to_bank3())
+			initialize_window(win_count, ROM3_DECODE_WINDOW,
+					  (uintptr_t)fch_spi_get_rom3_page(rom3_start + rom2_size),
+					  rom2_size, ext_win_size);
+		else
+			die("Can not map flash in ROM3 window!");
+
 		win_count++;
 		map_win_size += ext_win_size;
 	}
@@ -147,6 +197,9 @@ static void bios_mmap_init(void)
 const struct region_device *boot_device_ro(void)
 {
 	bios_mmap_init();
+
+	/* FSP might reconfigure it, so initialize again in every stage */
+	fch_spi_configure_4dw_burst();
 
 	return &real_dev.rdev;
 }


### PR DESCRIPTION
The CB:86620 change introduced checks for SPI ROM mapping during BIOS mmap windows initialization. This caused bricks on certain systems, because the fch_spi_rom_remapping does not give a complete view of how SPI ROM is mapped via ROM2 and ROM3.

The SPI_ROM_PAGE register contains the final XOR value applied to the host address to obtain the flash offset. However, for ROM2 there is also the SPI_ROM2_OVERRIDE register, which can apply bit masks on the ROM2 MMIO address bits 25:24 and forcefully remap host address to different flash offsets, or so called pages/banks. ROM3 is not affected by SPI_ROM2_OVERRIDE, only SPI_ROM_PAGE applies. Except when the bit 4 of SPI_ROM2_OVERRIDE is set, which enforces every 16MiB chunk in ROM3 to map to the SPI ROM bank 3 (for 64MB flash, it would be offset 0x3000000).

To get a final ROM2 mapping configuration for SPI ROM, the SPI_ROM2_OVERRIDE settings have to be applied first, then XORed with SPI_ROM_PAGE content.

Also different rules apply to ROM2/ROM3 if SPI ROM is configured for 32bit and 24bit address. With 24bit SPI ROM, the XOR does not apply.

Additionally for ROM3 mapping, allow a single 16MiB chunk to be mapped regardless if ROM3 mapping is linear or not. We only force ROM2 to map to flash offset 0, then the remaining 16MiB chunk of 32MiB flash is mapped at the ROM3 bank configured by FCH SPI registers. In the case flash is bigger than 32MiB, we require the ROM3 to be linear.

The implementation has been confirmed to work on the following SoCs:

- Phoenix AM5: 32MiB flash, SPI_ROM2_OVERRIDE = 0x14cc, SPI_ROM_PAGE = 0x00
- Turin: 32MiB flash, SPI_ROM2_OVERRIDE = 0x14c0, SPI_ROM_PAGE = 0x03

Information about SPI ROM mapping can be found in Phoenix A2 step PPR (doc 68053) and Turin PPR (doc 57238) section: "Programming for ROM Protection register". Additional information about FCH SPI ROM mapping is also available in Turin PPR in section: "ROM Address Mapping Support in FCH implementation".

TEST=Start bootblock on Gigabyte MZ33-AR1 (Turin) and MSI PRO B850-P WIFI (Phoenix AM5) and see that the die function on non-default mapping is no longer executed. SOC_AMD_COMMON_BLOCK_SPI_MMAP untested.

Change-Id: I215b63d1bc5626af62522f4b7daf4f779fa98bb7

Upstream-Status: Backport [CB:94146]